### PR TITLE
fix(ci): install uv in semantic-release build command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-build_command = "uv build"
+build_command = "pip install uv && uv build"
 commit_parser = "conventional"
 major_on_zero = false
 tag_format = "v{version}"


### PR DESCRIPTION
## Summary
- Fixes exit status 127 error in GitHub Actions CI/CD pipeline
- Updates semantic-release build_command to install uv before building
- Resolves python-semantic-release Docker container missing uv dependency

## Problem
The GitHub Actions workflow was failing with exit status 127 when python-semantic-release tried to execute `uv build`. This occurred because the python-semantic-release Docker container doesn't include uv by default.

## Solution
Modified the `build_command` in `pyproject.toml` to explicitly install uv before attempting to build:
```toml
build_command = "pip install uv && uv build"
```

## Changes
- **pyproject.toml**: Updated semantic-release build_command to install uv dependency
