### PR TITLE
fix(ci): resolve PyPI publish workflow artifact issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,11 @@ jobs:
           git_committer_name: "github-actions[bot]"
           git_committer_email: "github-actions[bot]@users.noreply.github.com"
 
+      - name: Build distribution packages
+        if: steps.release.outputs.released == 'true'
+        run: |
+          uv build
+
       - name: Publish to GitHub Release Assets
         uses: python-semantic-release/publish-action@v10.2.0
         if: steps.release.outputs.released == 'true'
@@ -55,22 +60,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
 
-  publish:
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    needs: release
-    if: needs.release.outputs.released == 'true'
-    
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
## Problem

The release workflow was failing at the "Publish to PyPI" step with the error:
```
Error: Unable to download artifact(s): Artifact not found for name: python-package-distributions
```

## Root Cause

The workflow had a separate `publish` job that tried to download artifacts that were never uploaded. The `release` job executed `python-semantic-release` but didn't build or upload distribution packages as artifacts.

## Solution

- **Consolidate build and publish**: Remove separate job and move everything to the `release` job
- **Add explicit build**: Add `uv build` step to create distribution packages
- **Simplify workflow**: Publish directly to PyPI without artifact transfer

## Technical Changes

- ✅ Add "Build distribution packages" step with `uv build`
- ✅ Remove separate `publish` job that was causing the error
- ✅ Move "Publish to PyPI" to the main `release` job
- ✅ Add condition `if: steps.release.outputs.released == 'true'` to publish step

## Notes

This fix follows official `python-semantic-release` v10 best practices, consolidating build and publish in a single job to avoid artifact transfer issues.