### PR TITLE
feat: add multiple credit card support for Santander scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,4 @@ outputs
 # Local development files (keep only locally)
 docs/
 CLAUDE.md
+TO_DO.md


### PR DESCRIPTION
## Summary

Adds support for scraping multiple credit cards in the Santander scraper. Previously, the scraper only extracted movements from the first visible card in the carousel. Now it detects all available credit cards and processes each one individually.

## Changes

- **New carousel detection system**: Extracts all credit card IDs from the carousel on both unbilled and billed pages
- **Card navigation**: Implements logic to navigate between cards in the carousel using the next button
- **Per-card processing**: Iterates through each detected card to extract both CLP and USD movements (billed and unbilled)
- **Fallback support**: Maintains backward compatibility with old behavior if carousel detection fails
- **Improved logging**: Added detailed logs for multi-card processing
- **Gitignore update**: Added TO_DO.md to .gitignore for local development files

## Motivation

Users with multiple Santander credit cards were only able to scrape movements from one card. This improvement allows complete transaction extraction across all cards in a single execution.

## Test Plan

- [x] Test with single credit card (backward compatibility)
- [x] Test with multiple credit cards (new functionality)
- [x] Verify carousel navigation works correctly
- [x] Confirm all currencies (CLP/USD) are scraped for each card
- [x] Check debug mode captures screenshots for each card
- [x] Validate fallback behavior when carousel detection fails

## Related Issues

Closes #[issue-number] (if applicable)