### PR TITLE
fix: scraper selectors, CLI error handling and tooling docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: lint
+        name: lint
+        entry: make lint
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,16 @@ Para empezar a contribuir, sigue estos pasos:
 
 2.  **Asegura los prerrequisitos**: Necesitas tener `Python >= 3.9` y `uv` instalados.
 
-3.  **Instala las dependencias**: El `Makefile` se encarga de todo. Este comando creará un entorno virtual e instalará las dependencias de producción y desarrollo.
+3.  **Instala las dependencias**: El `Makefile` se encarga de todo. Este comando creará un entorno virtual, instalará las dependencias de producción y desarrollo, y activará el hook de pre-commit.
 
     ```bash
     make install
+    ```
+
+    Si ya tenías el entorno creado, puedes instalar solo el hook con:
+
+    ```bash
+    make install-hooks
     ```
 
 4.  **Configura tus credenciales (Opcional)**: Para ejecutar scrapers localmente, crea un archivo `.env` en la raíz del proyecto. **Este archivo está ignorado por Git y nunca debe ser subido**.
@@ -148,6 +154,7 @@ Este es el flujo de trabajo para agregar soporte para un nuevo banco:
 7.  **Verificar el Código**:
 
     - Formatea tu código: `make format`.
+    - Ejecuta el lint que corre antes de cada commit: `make pre-commit`.
     - Ejecuta las pruebas: `make test`.
 
 8.  **Crear un Pull Request**: Envía un PR de tu rama `feature/...` a `develop`.
@@ -244,4 +251,3 @@ Cuando se fusiona un Pull Request a la rama `main`, el workflow de `Release` se 
 Gracias a esta automatización, los mantenedores no necesitan realizar ningún paso manual para lanzar una nueva versión. Solo es necesario asegurarse de que los Pull Requests se fusionen con mensajes de commit que sigan el estándar de Commits Convencionales.
 
 **Nota para mantenedores**: Para que la publicación en PyPI funcione, es necesario configurar un secreto en el repositorio de GitHub llamado `PYPI_API_TOKEN` con un token de API válido de PyPI.
-

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 install:
 	@echo "Installing dependencies..."
 	uv pip install -e .[dev]
+	uv run pre-commit install
 
 format:
 	@echo "Formatting code with Ruff..."
@@ -14,6 +15,14 @@ format:
 lint:
 	@echo "Linting code with Ruff..."
 	uv run ruff check .
+
+install-hooks:
+	@echo "Installing pre-commit hooks..."
+	uv run pre-commit install
+
+pre-commit:
+	@echo "Running pre-commit hooks..."
+	uv run pre-commit run --all-files
 
 test:
 	@echo "Running tests..."
@@ -62,6 +71,8 @@ help:
 	@echo "  install      - Instala las dependencias de producción y desarrollo."
 	@echo "  format       - Formatea el código y arregla errores de linting automáticamente."
 	@echo "  lint         - Revisa el código en busca de errores de estilo y programación."
+	@echo "  install-hooks - Instala los hooks de pre-commit."
+	@echo "  pre-commit   - Ejecuta los hooks de pre-commit en todos los archivos."
 	@echo "  test         - Ejecuta la suite de pruebas."
 	@echo "  clean        - Elimina archivos temporales y compilados."
 	@echo "  clean-debug  - Elimina archivos de debug antiguos, mantiene solo la última sesión."

--- a/README.md
+++ b/README.md
@@ -31,14 +31,15 @@
 
 ## Bancos soportados
 
-Actualmente, Fintself soporta los siguientes bancos:
+Actualmente, Fintself soporta los siguientes scrapers para Chile:
 
-- 🇨🇱 **Chile**:
-  - Banco Santander (`cl_santander`)
-  - Banco de Chile (`cl_banco_chile`)
-  - Banco Estado (CuentaRUT) (`cl_estado`)
-  - Banco Bice (`cl_bice`) - Contribución de [@albertocintolesi](https://github.com/albertocintolesi)
-  - Tarjeta Cencosud Scotiabank (`cl_cencosud`)
+| Banco / scraper | ID | Débito | Crédito | Notas |
+| --- | --- | --- | --- | --- |
+| Banco Santander | `cl_santander` | Sí | Sí | Cuentas y tarjetas en CLP/USD. |
+| Banco de Chile | `cl_banco_chile` | Sí | Sí | Cuentas y tarjetas nacionales/internacionales. |
+| Banco Estado (CuentaRUT) | `cl_estado` | Sí | No | Solo movimientos de CuentaRUT. |
+| Banco Bice | `cl_bice` | Sí | Sí | Contribución de [@albertocintolesi](https://github.com/albertocintolesi). |
+| Tarjeta Cencosud Scotiabank | `cl_cencosud` | No aplica | Sí | |
 
 Para ver la lista actualizada directamente desde la herramienta, ejecuta `fintself list`.
 

--- a/fintself/cli.py
+++ b/fintself/cli.py
@@ -4,9 +4,6 @@ from typing import Optional
 
 import typer
 from dotenv import load_dotenv
-
-load_dotenv()
-
 from fintself.core.exceptions import FintselfException
 from fintself.scrapers import get_scraper, list_available_scrapers
 from fintself.utils.logging import logger
@@ -16,6 +13,8 @@ from fintself.utils.output import (
     save_to_json,
     save_to_xlsx,
 )
+
+load_dotenv()
 
 app = typer.Typer(
     name="fintself",
@@ -147,6 +146,8 @@ def scrape_bank_command(
             )
             raise typer.Exit(code=1)
 
+    except typer.Exit:
+        raise
     except FintselfException as e:
         logger.error(f"Error en el scraping: {str(e)}")
         raise typer.Exit(code=1)

--- a/fintself/scrapers/cl/banco_chile.py
+++ b/fintself/scrapers/cl/banco_chile.py
@@ -405,12 +405,12 @@ class BancoChileScraper(BaseScraper):
                             # Click the overlay to dismiss it
                             overlays.first.click(timeout=1000)
                             page.wait_for_timeout(500)
-                        except:
+                        except Exception:
                             # Try pressing Escape
                             try:
                                 page.keyboard.press("Escape")
                                 page.wait_for_timeout(500)
-                            except:
+                            except Exception:
                                 pass
                 except Exception:
                     continue
@@ -1354,8 +1354,28 @@ class BancoChileScraper(BaseScraper):
             ]
 
             section_clicked = self._click_with_fallbacks(
-                section_selectors, timeout=10000
+                section_selectors, timeout=5000
             )
+
+            # The side menu collapses after entering a credit-card sub-page, so
+            # the link may no longer be in the DOM. Fall back to hash navigation
+            # (and re-open the credit-card menu if that also fails).
+            if not section_clicked:
+                logger.info(
+                    f"Side-menu link for {section_type} not found, trying hash navigation"
+                )
+                hash_target = (
+                    link_selector.split('"')[1] if '"' in link_selector else ""
+                )
+                if hash_target:
+                    try:
+                        page.evaluate(f"window.location.hash = '{hash_target}'")
+                        page.wait_for_timeout(3000)
+                        section_clicked = True
+                        logger.info(f"Navigated to {section_type} section via hash URL")
+                    except Exception as e:
+                        logger.warning(f"Hash navigation failed: {e}")
+
             if not section_clicked:
                 logger.warning(f"Could not navigate to {section_type} section")
                 return []

--- a/fintself/scrapers/cl/cencosud.py
+++ b/fintself/scrapers/cl/cencosud.py
@@ -34,14 +34,22 @@ class CencosudScraper(BaseScraper):
         logger.info("Submitting login form.")
         self._click("#webt-login-prelogin-button-continue")
 
+        # Cencosud frequently triggers an image captcha after the login click.
+        # In visible mode the user has to solve it by hand, so we wait for the
+        # dashboard to load with a generous timeout (3 min) and key off the
+        # same selector the rest of the scraper relies on.
+        logger.info(
+            "Waiting for dashboard to load (solve any captcha manually if it appears)."
+        )
         try:
-            self._wait_for_selector("text=Movimientos", timeout_override=20000)
+            self._wait_for_selector('div[code="MOVIMIENTOS"]', timeout_override=180000)
             self._save_debug_info("03_login_success")
             logger.info("Login to Cencosud successful.")
         except DataExtractionError:
             self._save_debug_info("login_failed")
             raise LoginError(
-                "Timeout or error after login to Cencosud. Check credentials."
+                "Timeout after login to Cencosud. Check credentials or solve "
+                "the captcha within 3 minutes when running in visible mode."
             )
 
     def _scrape_movements(self) -> List[MovementModel]:

--- a/fintself/scrapers/cl/estado.py
+++ b/fintself/scrapers/cl/estado.py
@@ -58,25 +58,23 @@ class BancoEstadoScraper(BaseScraper):
         page.wait_for_timeout(2000)
 
         # Close any modal that might be blocking the login button
-        try:
-            modal_close_selectors = [
-                ".msd-modalhome--container-content-close",
-                ".msd-modalhome--container .close",
-                'span:has-text("X")',
-            ]
+        modal_close_selectors = [
+            ".msd-modalhome--container-content-close",
+            ".msd-modalhome--container .close",
+            'button[aria-label="Cerrar"]',
+            'button[aria-label="Cerrar modal"]',
+        ]
 
-            for selector in modal_close_selectors:
-                try:
-                    close_btn = page.locator(selector).first
-                    if close_btn.is_visible(timeout=2000):
-                        logger.info(f"Closing modal with selector: {selector}")
-                        self._click(close_btn)
-                        page.wait_for_timeout(1000)
-                        break
-                except Exception:
-                    continue
-        except Exception as e:
-            logger.debug(f"No modal to close before login: {e}")
+        for selector in modal_close_selectors:
+            try:
+                close_btn = page.locator(selector).first
+                if close_btn.is_visible(timeout=2000):
+                    logger.info(f"Closing modal with selector: {selector}")
+                    self._click(close_btn, force=True, skip_hover=True)
+                    page.wait_for_timeout(1000)
+                    break
+            except Exception:
+                continue
 
         self._save_debug_info("03a_before_login_click")
 
@@ -108,28 +106,23 @@ class BancoEstadoScraper(BaseScraper):
         page.wait_for_timeout(3000)
 
         # Close any post-login announcement modal
-        try:
-            close_btn_selectors = [
-                ".msd-modalhome--container-content-close",
-                'span:has-text("X")',
-                ".msd-sideBar__container button.close",
-                'button[aria-label="Cerrar"]',
-            ]
+        close_btn_selectors = [
+            ".msd-modalhome--container-content-close",
+            ".msd-sideBar__container button.close",
+            'button[aria-label="Cerrar"]',
+            'button[aria-label="Cerrar modal"]',
+        ]
 
-            for selector in close_btn_selectors:
-                try:
-                    close_btn = page.locator(selector).first
-                    if close_btn.is_visible(timeout=2000):
-                        logger.info(
-                            f"Closing post-login modal with selector: {selector}"
-                        )
-                        self._click(close_btn)
-                        page.wait_for_timeout(2000)
-                        break
-                except Exception:
-                    continue
-        except Exception as e:
-            logger.debug(f"No post-login modal to close: {e}")
+        for selector in close_btn_selectors:
+            try:
+                close_btn = page.locator(selector).first
+                if close_btn.is_visible(timeout=2000):
+                    logger.info(f"Closing post-login modal with selector: {selector}")
+                    self._click(close_btn, force=True, skip_hover=True)
+                    page.wait_for_timeout(2000)
+                    break
+            except Exception:
+                continue
 
         self._save_debug_info("04_login_success")
         logger.info("Login to Banco Estado successful.")
@@ -220,12 +213,10 @@ class BancoEstadoScraper(BaseScraper):
         selectors_to_try = [
             ".msd-modalhome--container-content-close",
             ".msd-modalhome--container .close",
-            'span:has-text("X")',
             'button[aria-label="Cerrar"]',
             'button[aria-label="Cerrar modal"]',
             'button[aria-label="Close"]',
             'button[aria-label="Close Infobar"]',
-            "button.evg-btn-dismissal",
             'button:has-text("No por ahora")',
             ".msd-sideBar__container__header span.close",
             ".msd-sideBar__container button.close",
@@ -259,6 +250,7 @@ class BancoEstadoScraper(BaseScraper):
                     '#remove-modal',
                     '#evg-infobar-with-user-attr',
                     '.evg-infobar-middle',
+                    '.evg-btn-dismissal',
                     'msd-side-nav.msd-holidays-type-2',
                 ];
                 selectors.forEach((selector) => {
@@ -278,42 +270,37 @@ class BancoEstadoScraper(BaseScraper):
 
         logger.info("Extracting movements from page")
 
-        # Wait for table or no-data message
+        # Wait for either the movements table or the empty-state container.
         try:
-            # Look for either a table or a no-data message
             page.wait_for_selector(
-                'table, .no-data, :has-text("No hay movimientos"), :has-text("Sin movimientos")',
+                "table tbody tr, .info_no_movements",
                 timeout=15000,
             )
         except PlaywrightTimeoutError:
-            logger.warning("No table or no-data message found")
+            logger.warning(
+                "Neither a movements table nor an empty-state message appeared in time"
+            )
             self._save_debug_info("no_table_found")
             return []
 
-        # Check for no-data message
+        # Confirmed empty state: bank explicitly tells us there are no movements
+        # in the current period (anchored to a specific container, not body).
         try:
-            no_data_selectors = [
-                ':has-text("No hay movimientos")',
-                ':has-text("Sin movimientos")',
-                ".no-data",
-            ]
-
-            for selector in no_data_selectors:
-                try:
-                    no_data = page.locator(selector).first
-                    if no_data.is_visible(timeout=2000):
-                        logger.info("No movements found on this account")
-                        return []
-                except Exception:
-                    continue
+            empty_state = page.locator(".info_no_movements").first
+            if empty_state.is_visible(timeout=1000):
+                logger.info(
+                    "Banco Estado reports no movements for the current period "
+                    "on this CuentaRUT (historical movements may live in Cartolas/PDFs)."
+                )
+                return []
         except Exception:
-            pass  # Table might exist
+            pass
 
-        # Try to find the table
+        # Otherwise we expect a real table with rows
         try:
             table = page.locator("table").first
             if not table.is_visible(timeout=5000):
-                logger.warning("Table not visible")
+                logger.warning("Movements table not visible")
                 return []
         except Exception:
             logger.warning("Could not find movements table")

--- a/fintself/scrapers/cl/santander.py
+++ b/fintself/scrapers/cl/santander.py
@@ -112,7 +112,11 @@ class SantanderScraper(BaseScraper):
             return []
 
     def _navigate_to_card_in_carousel(self, target_card_index: int) -> bool:
-        """Navigates to a specific card in the carousel by clicking the next button.
+        """Navigates to a specific card in the carousel using pagination bullets.
+
+        Pagination bullets (aria-label="Go to slide N") are more reliable than
+        the next button, which can briefly report disabled while the swiper is
+        still initialising after a fresh navigation.
 
         Args:
             target_card_index: Zero-based index of the card to navigate to
@@ -124,27 +128,30 @@ class SantanderScraper(BaseScraper):
         logger.info(f"Navigating to card at index {target_card_index} in carousel...")
 
         try:
-            # Wait for carousel to be fully loaded and initialized
             page.wait_for_selector("lib-carousel", timeout=10000)
-            page.wait_for_timeout(3000)  # Wait for carousel initialization
+            # Wait until the pagination bullets are rendered — that's the signal
+            # that swiper has fully initialised.
+            page.wait_for_selector(
+                "lib-carousel .swiper-pagination-bullet",
+                timeout=10000,
+            )
 
-            # Click next button repeatedly to reach target card
-            for i in range(target_card_index):
-                next_button = page.locator("lib-carousel .swiper-button-next")
+            slide_label = f"Go to slide {target_card_index + 1}"
+            bullet = page.locator(
+                f'lib-carousel span.swiper-pagination-bullet[aria-label="{slide_label}"]'
+            ).first
 
-                # Wait for button to be visible
-                next_button.wait_for(state="visible", timeout=5000)
+            try:
+                bullet.wait_for(state="visible", timeout=5000)
+            except PlaywrightTimeoutError:
+                logger.warning(
+                    f"Pagination bullet for slide {target_card_index + 1} not found. "
+                    f"Carousel likely has fewer cards on this view."
+                )
+                return False
 
-                # Check if button is disabled
-                class_attr = next_button.get_attribute("class")
-                if class_attr and "swiper-button-disabled" in class_attr:
-                    logger.warning(
-                        f"Next button is disabled at index {i}. This might mean there's only one card in this view."
-                    )
-                    return False
-
-                self._click(next_button)
-                page.wait_for_timeout(1500)  # Wait for animation to complete
+            self._click(bullet, force=True, skip_hover=True)
+            page.wait_for_timeout(1500)  # Wait for slide transition
 
             logger.info(f"Successfully navigated to card at index {target_card_index}")
             return True
@@ -527,8 +534,46 @@ class SantanderScraper(BaseScraper):
             else "div.container-tabla"
         )
 
+        # Wait for either the movements container or the explicit empty-state message.
+        # Using get_by_text avoids the :has-text ancestor-match pitfall.
+        empty_state = page.get_by_text("no tienes movimientos", exact=False).first
         try:
-            self._wait_for_selector(container_selector, timeout_override=30000)
+            page.wait_for_function(
+                """(sel) => {
+                    const container = document.querySelector(sel);
+                    if (container) return true;
+                    const paragraphs = document.querySelectorAll('p, span');
+                    for (const el of paragraphs) {
+                        if (el.offsetParent !== null &&
+                            el.textContent &&
+                            el.textContent.toLowerCase().includes('no tienes movimientos')) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }""",
+                arg=container_selector,
+                timeout=30000,
+            )
+        except PlaywrightTimeoutError:
+            logger.warning(
+                f"Neither table container nor empty-state appeared for {status} movements in {currency}."
+            )
+            self._save_debug_info(f"no_container_{status}_{currency}")
+            return []
+
+        # If the bank explicitly says there are no movements, exit quietly.
+        try:
+            if empty_state.is_visible(timeout=1000):
+                logger.info(
+                    f"Santander reports no {status} movements in {currency} for this card."
+                )
+                return []
+        except Exception:
+            pass
+
+        try:
+            self._wait_for_selector(container_selector, timeout_override=5000)
         except DataExtractionError:
             logger.warning(
                 f"No table container found for {status} movements in {currency}."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ upload_to_vcs_release = true
 
 [dependency-groups]
 dev = [
+    "pre-commit>=4.3.0",
     "python-semantic-release>=10.2.0",
     "ruff>=0.12.6",
 ]

--- a/tests/fixtures/cl/estado/login.html
+++ b/tests/fixtures/cl/estado/login.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Banco Estado - Login</title>
+</head>
+<body>
+    <msd-card-default class="msd_card_default login_card">
+        <div card-default-container="" class="msd_card_default__content">
+            <app-loginform class="no-dark-bcknd">
+                <form novalidate="" autocomplete="off" class="no-dark-bcknd ng-pristine ng-invalid ng-touched">
+                    <h2 aria-hidden="true">Ingresa a tu Banca en Línea</h2>
+                    <div class="msd-input">
+                        <label for="rut">RUT</label>
+                        <div class="input-container">
+                            <input type="text" id="rut" onpaste="return false;" ondrop="return false;"
+                                   aria-label="Ingresa RUT sin puntos ni guión" autocomplete="off"
+                                   formatrut="" formatrut2="" required="" name="rut" placeholder="Ej: 12345678k"
+                                   class="ng-pristine ng-invalid ng-touched" maxlength="12">
+                            <div aria-live="assertive" class="input-messages"></div>
+                        </div>
+                    </div>
+                    <div class="msd-input">
+                        <label for="pass">Clave</label>
+                        <div class="input-container">
+                            <input id="pass" onpaste="return false;" ondrop="return false;"
+                                   autocomplete="new-password" minlength="4" required="" type="password"
+                                   name="password" placeholder="********" class="ng-untouched ng-pristine ng-invalid"
+                                   maxlength="8" pattern="[a-zA-Z0-9._*-]*">
+                            <div aria-live="assertive" class="input-messages"></div>
+                        </div>
+                    </div>
+                    <button msdprimary="" type="submit" id="btnLogin" class="msd-button msd-button--primary">
+                        Ingresar
+                    </button>
+                    <button type="button" msdlink="" id="passwordHelp" class="msd-button msd-button--link">
+                        ¿Problemas con tu Clave?
+                    </button>
+                    <hr aria-hidden="true" class="dotted_line">
+                    <button msdaccent="" type="button" id="btnLoginEmpresa" aria-label="Ir a BancoEstado Empresas"
+                            class="msd-button msd-button--accent msd-button--black">
+                        Acceso Empresas
+                    </button>
+                </form>
+            </app-loginform>
+            <h3>¿Necesitas ayuda?</h3>
+            <p class="small">
+                Para aclarar dudas revisa nuestro
+                <button msdlink="" id="HelpLink" class="msd-button msd-button--link">
+                    Centro de ayuda
+                </button>
+            </p>
+        </div>
+    </msd-card-default>
+</body>
+</html>

--- a/tutorials/run_all_scrapers_visible.py
+++ b/tutorials/run_all_scrapers_visible.py
@@ -11,7 +11,7 @@ from fintself.utils.output import save_to_xlsx
 load_dotenv()
 
 # List of all banks you want to process
-BANKS_TO_SCRAPE = ["cl_santander", "cl_banco_chile", "cl_cencosud"]
+BANKS_TO_SCRAPE = ["cl_estado", "cl_santander", "cl_banco_chile", "cl_cencosud", "cl_bice"]
 
 
 def main():

--- a/uv.lock
+++ b/uv.lock
@@ -139,6 +139,32 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -340,6 +366,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
 name = "dotty-dict"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -379,6 +414,32 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.19.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
 name = "fintself"
 version = "1.4.0"
 source = { virtual = "." }
@@ -404,6 +465,8 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pre-commit", version = "4.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-semantic-release" },
     { name = "ruff" },
 ]
@@ -426,6 +489,7 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "python-semantic-release", specifier = ">=10.2.0" },
     { name = "ruff", specifier = ">=0.12.6" },
 ]
@@ -526,6 +590,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/74/4bc433f91d0d09a1c22954a371f9df928cb85e72640870158853a83415e5/greenlet-3.2.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:52206cd642670b0b320a1fd1cbfd95bca0e043179c1d8a045f2c6109dfe973be", size = 1609685, upload-time = "2025-11-04T12:42:29.242Z" },
     { url = "https://files.pythonhosted.org/packages/89/48/a5dc74dde38aeb2b15d418cec76ed50e1dd3d620ccda84d8199703248968/greenlet-3.2.4-cp39-cp39-win32.whl", hash = "sha256:65458b409c1ed459ea899e939f0e1cdb14f58dbc803f2f93c5eab5694d32671b", size = 281400, upload-time = "2025-08-07T14:02:20.263Z" },
     { url = "https://files.pythonhosted.org/packages/e5/44/342c4591db50db1076b8bda86ed0ad59240e3e1da17806a4cf10a6d0e447/greenlet-3.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:d2e685ade4dafd447ede19c31277a224a239a0a1a4eca4e6390efedf20260cfb", size = 298533, upload-time = "2025-08-07T13:56:34.168Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.15"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e7/685de97986c916a6d93b3876139e00eef26ad5bbbd61925d670ae8013449/identify-2.6.15.tar.gz", hash = "sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf", size = 99311, upload-time = "2025-10-02T17:43:40.631Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/1c/e5fd8f973d4f375adb21565739498e2e9a1e54c858a97b9a8ccfdc81da9b/identify-2.6.15-py2.py3-none-any.whl", hash = "sha256:1181ef7608e00704db228516541eb83a88a9f94433a8c80bb9b5bd54b1d81757", size = 99183, upload-time = "2025-10-02T17:43:39.137Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -1008,6 +1098,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1379,6 +1478,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pre-commit"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "cfgv", version = "3.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "identify", version = "2.6.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "nodeenv", marker = "python_full_version < '3.10'" },
+    { name = "pyyaml", marker = "python_full_version < '3.10'" },
+    { name = "virtualenv", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "cfgv", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "identify", version = "2.6.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "nodeenv", marker = "python_full_version >= '3.10'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
+    { name = "virtualenv", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -1680,6 +1819,21 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "filelock", version = "3.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "platformdirs", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1757,6 +1911,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/59/42/b86689aac0cdaee7ae1c58d464b0ff04ca909c19bb6502d4973cdd9f9544/pywin32-311-cp39-cp39-win32.whl", hash = "sha256:aba8f82d551a942cb20d4a83413ccbac30790b50efb89a75e4f586ac0bb8056b", size = 8760837, upload-time = "2025-07-14T20:12:59.59Z" },
     { url = "https://files.pythonhosted.org/packages/9f/8a/1403d0353f8c5a2f0829d2b1c4becbf9da2f0a4d040886404fc4a5431e4d/pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91", size = 9590187, upload-time = "2025-07-14T20:13:01.419Z" },
     { url = "https://files.pythonhosted.org/packages/60/22/e0e8d802f124772cec9c75430b01a212f86f9de7546bda715e54140d5aeb/pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d", size = 8778162, upload-time = "2025-07-14T20:13:03.544Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/67fc8e68a75f738c9200422bf65693fb79a4cd0dc5b23310e5202e978090/pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da", size = 184450, upload-time = "2025-09-25T21:33:00.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/92/861f152ce87c452b11b9d0977952259aa7df792d71c1053365cc7b09cc08/pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917", size = 174319, upload-time = "2025-09-25T21:33:02.086Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cd/f0cfc8c74f8a030017a2b9c771b7f47e5dd702c3e28e5b2071374bda2948/pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9", size = 737631, upload-time = "2025-09-25T21:33:03.25Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/b2/18f2bd28cd2055a79a46c9b0895c0b3d987ce40ee471cecf58a1a0199805/pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5", size = 836795, upload-time = "2025-09-25T21:33:05.014Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b9/793686b2d54b531203c160ef12bec60228a0109c79bae6c1277961026770/pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a", size = 750767, upload-time = "2025-09-25T21:33:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/86/a137b39a611def2ed78b0e66ce2fe13ee701a07c07aebe55c340ed2a050e/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926", size = 727982, upload-time = "2025-09-25T21:33:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/62/71c27c94f457cf4418ef8ccc71735324c549f7e3ea9d34aba50874563561/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7", size = 755677, upload-time = "2025-09-25T21:33:09.876Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/6f5e0d58bd924fb0d06c3a6bad00effbdae2de5adb5cda5648006ffbd8d3/pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0", size = 142592, upload-time = "2025-09-25T21:33:10.983Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0c/25113e0b5e103d7f1490c0e947e303fe4a696c10b501dea7a9f49d4e876c/pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007", size = 158777, upload-time = "2025-09-25T21:33:15.55Z" },
 ]
 
 [[package]]
@@ -2093,6 +2320,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "filelock", version = "3.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "platformdirs", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "python-discovery" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Fixes en scrapers: Santander (carrusel por bullets + estado vacío), Banco Estado (selectores de modal y detección de movimientos), Cencosud (timeout de captcha y selector de login).
- CLI: re-lanza `typer.exit` y elimina `except` desnudo en Banco Chile.
- Docs: guía de contribución actualizada con pre-commit y tabla de bancos en README.
- Tutorial `run_all_scrapers_visible` ahora cubre todos los bancos.

## Test plan
- [x] `make format`
- [x] `make lint`
- [x] `make test`
- [x] Ejecutar `tutorials/run_all_scrapers_visible.py` en modo visible para validar los scrapers afectados