### PR TITLE
feat: add Scotiabank Chile scraper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@
 # CL_ESTADO_PASSWORD=""
 # CL_BICE_USER=""
 # CL_BICE_PASSWORD=""
+# CL_SCOTIABANK_USER=""
+# CL_SCOTIABANK_PASSWORD=""
 
 # Configuración de Scrapers (opcional, valores por defecto mostrados)
 # --------------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,11 @@ __marimo__/
 outputs
 
 # Local development files (keep only locally)
-docs/
+docs/*
+!docs/scrapers
+!docs/scrapers/**
 CLAUDE.md
 TO_DO.md
+RESUME.md
+/recon/
+scripts/_*.py

--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,10 @@ TO_DO.md
 RESUME.md
 /recon/
 scripts/_*.py
+# Browser profiles + session artifacts (stealth scraping)
+*-profile/
+chrome-data/
+user-data-dir/
+*.session
+*.pickle
+debug/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,15 @@ Este es el flujo de trabajo para agregar soporte para un nuevo banco:
     - Mientras desarrollas, guarda el contenido HTML de las páginas clave (login, movimientos, etc.).
     - Crea una carpeta en `tests/fixtures/codigo_iso_pais/nombre_banco/`.
     - Guarda los archivos HTML ahí. _Ejemplo_: `login.html`, `movements_page_1.html`.
-    - **Importante**: Edita los archivos HTML para eliminar cualquier información personal o sensible.
+    - **Importante**: Edita los archivos HTML para eliminar cualquier información personal o sensible. Checklist mínima de sanitización (revisa cada uno antes de hacer commit):
+        - [ ] **RUTs**: reemplaza con `XX.XXX.XXX-X` cualquier patrón `\d{1,2}\.\d{3}\.\d{3}-[\dkK]` y `XXXXXXX-X` para `\d{7,8}-[\dkK]` (RUT sin puntos).
+        - [ ] **Tarjetas**: reemplaza últimos 4 dígitos `****\d{4}` por `****XXXX`.
+        - [ ] **Números de cuenta**: reemplaza secuencias de 9+ dígitos dentro de celdas con `XXXXXXXXX`.
+        - [ ] **Nombres**: en descripciones de transferencias (`TEF`, `TRANSF`, `ABONO`, `SBP`, `PAGO TARJETA`), reemplaza nombres propios por `NOMBRE APELLIDO`.
+        - [ ] **Saludos personalizados**: reemplaza `Hola, <Nombre>` por `Hola, USUARIO`.
+        - [ ] **IDs de pago/tax**: reemplaza patrones tipo `SII <8+ dígitos>` por `SII XXXXXXXX`.
+        - [ ] **Verificación final**: `grep -E '\b\d{1,2}\.\d{3}\.\d{3}-[\dkK]\b|\b\d{7,8}-[\dkK]\b|\*{2,}\d{4}\b' tests/fixtures/<pais>/<banco>/*.html` debe devolver cero resultados.
+    - Considera añadir un `README.md` en la carpeta de fixtures describiendo qué representa cada archivo, la fecha de captura y la URL de origen.
 
 5.  **Escribir las Pruebas**:
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Actualmente, Fintself soporta los siguientes scrapers para Chile:
 | Banco Estado (CuentaRUT) | `cl_estado` | Sí | No | Solo movimientos de CuentaRUT. |
 | Banco Bice | `cl_bice` | Sí | Sí | Contribución de [@albertocintolesi](https://github.com/albertocintolesi). |
 | Tarjeta Cencosud Scotiabank | `cl_cencosud` | No aplica | Sí | |
+| Scotiabank Chile | `cl_scotiabank` | Sí | Sí | Cuenta corriente y tarjeta de crédito (facturadas y no facturadas). [^1] |
+
+[^1]: Probado solo con una única cuenta corriente (CTACTE) y una sola tarjeta de crédito. Perfiles con múltiples cuentas o tarjetas requieren un paso de selección que aún no está implementado; los productos adicionales serían omitidos. Contribuciones bienvenidas.
 
 Para ver la lista actualizada directamente desde la herramienta, ejecuta `fintself list`.
 

--- a/docs/scrapers/recon/cl_scotiabank.md
+++ b/docs/scrapers/recon/cl_scotiabank.md
@@ -1,0 +1,230 @@
+# Scotiabank Chile — recon
+
+Sanitized recon notes for the `cl_scotiabank` scraper. The full working notes (with timing observations and screenshots) live under `recon/scotiabank_notes.md` (gitignored).
+
+## Login flow
+
+```
+PUBLIC_HOME_URL = "https://www.scotiabankchile.cl/"
+PUBLIC_LOGIN_BUTTON = 'text=Acceso Scotia'   # use .first (appears 2-3x)
+PUBLIC_LOGIN_PERSONAS = 'role=link[name="Ingreso Personas"]'
+
+# Post-redirect SPA login (URL has CSRF-like token in `?c=...`):
+LOGIN_URL_PREFIX = "https://banco.scotiabank.cl/mfe-login/scotia"
+
+RUT_INPUT      = '[data-testid="inputDni"]'   # RUT with dots+dash
+PASSWORD_INPUT = '[data-testid="inputPassword"]'
+SUBMIT_BUTTON  = 'role=button[name="Ingresar"]'
+
+DASHBOARD_URL_FRAGMENT = "/mfe-home-cl/"
+```
+
+⚠️ **DO NOT** use `button:has-text('Cerrar')` for any tour-dismissal heuristic — that string is the **logout** button text on the dashboard. Use the `TOUR_DISMISS_SELECTORS` list in `ScotiabankScraper` instead.
+
+### Tour-dismiss safety
+
+`_dismiss_onboarding_tour` polls the `TOUR_DISMISS_SELECTORS` list (driver.js
+close button, `Saltar`, `Omitir`, `Entendido`, `Finalizar tour`, `Listo`, and
+scoped `[role='dialog'] button[aria-label='Cerrar']` / `.modal button[aria-label='Cerrar']`).
+The bare text `Cerrar` is intentionally absent: the dashboard renders a
+**logout** button whose label is `Cerrar sesión`, and a substring match would
+log the user out mid-scrape. Any new heuristic added here MUST scope `Cerrar`
+to a dialog/modal ancestor or rely on `aria-label="Cerrar"`.
+
+## Dashboard navigation
+
+Top-menu items render as `<span class="menu-column--item__title">` nested inside clickable parents. Reliable click via `page.get_by_text("Cuentas")` / `page.get_by_text("Tarjetas")`.
+
+Dashboard cards expose direct links like `Ver cartola` / `Ver saldos` (`span.StandaloneLinkstyle__Text-canvas-core`).
+
+## Iframe shell
+
+All movement data renders inside `<iframe id="iframe-stage">`. Outer page only hosts the chrome (menu, footer). Use:
+
+```python
+frame = page.frame_locator("#iframe-stage")
+# or
+for f in page.frames:
+    if "mfe-accounts-balancesmovements-web" in f.url:
+        ...
+```
+
+Iframe URLs by section:
+
+| Section            | URL fragment                                           |
+|--------------------|--------------------------------------------------------|
+| Checking           | `mfe-accounts-balancesmovements-web/?tab=saldos&type=CTACTE` |
+| CC (billed/unbilled) | `mfe-simple-account-statement-web-cl/?tab=movimientos-facturados` |
+
+CC billed and unbilled share the same MFE; tabs switch content.
+
+⚠️ The page actually attaches **two** frames whose URL contains the section
+fragment: the outer shell wrapper (URL also contains `mfe-shell`) and the
+inner content frame (no `mfe-shell` segment). Only the inner frame hosts the
+table DOM. `_get_stage_frame` MUST filter out any frame whose URL contains
+`mfe-shell` and keep polling until the inner content frame is attached —
+returning the shell wrapper produces empty selectors and a misleading
+"table did not render" failure.
+
+### Per-tab shell URLs
+
+Each section navigates to a dedicated shell URL so Playwright lands on a
+fresh iframe state. Reusing one URL and clicking the tab leaks the previous
+pane's DOM (both panes stay mounted) and causes duplicate extractions.
+
+| Constant | URL | Returns |
+|----------|-----|---------|
+| `CHECKING_SHELL_URL` | `…/mfe-accounts-balancesmovements-web/?tab=saldos&type=CTACTE` | Checking ("Saldos y últimos movimientos") for the auto-selected CTACTE. |
+| `CC_BILLED_SHELL_URL` | `…/mfe-simple-account-statement-web-cl/?tab=movimientos-facturados` | CC movements already billed in the current statement, with the Facturados tab pre-active. |
+| `CC_UNBILLED_SHELL_URL` | `…/mfe-simple-account-statement-web-cl/?tab=movimientos-no-facturados` | CC movements still pending billing, with the No-facturados tab pre-active. |
+
+All three are built from `SHELL_BASE = "https://www.scotiabank.cl/mfe/sweb/mfe-shell-web-cl/mfe/"`.
+
+## Live extraction flow
+
+End-to-end order followed by `ScotiabankScraper.scrape`, citing the constants
+used at each step:
+
+1. **Public navigation** → `HOME_URL` (`https://www.scotiabankchile.cl/`).
+2. **Open login** → click first `PUBLIC_LOGIN_TEXT` ("Acceso Scotia"), then
+   `PUBLIC_LOGIN_PERSONAS_NAME` ("Ingreso Personas") link.
+3. **SPA login form** → wait for `RUT_INPUT`, type RUT and password into
+   `RUT_INPUT` / `PASSWORD_INPUT`, click `SUBMIT_BUTTON`. Expect URL to match
+   `DASHBOARD_URL_FRAGMENT` (`/mfe-home-cl/`).
+4. **Tour dismissal** → `_dismiss_onboarding_tour` polls
+   `TOUR_DISMISS_SELECTORS` for up to `POST_LOGIN_SETTLE_MS` (8000 ms).
+5. **Checking** → navigate to `CHECKING_SHELL_URL`, run a short
+   `TOUR_PRE_NAV_MS` (500 ms) tour sweep, then `_get_stage_frame(CHECKING_IFRAME_URL_FRAGMENT)`
+   and wait for `CHECKING_TABLE` (`table.Table__dataTable`). Parse rows with
+   `CHECKING_ROW` / `CHECKING_CELL`.
+6. **CC billed** → `_scrape_cc_tab(CC_BILLED_SHELL_URL, TAB_BILLED_SELECTOR, "Facturado")`.
+7. **CC unbilled** → `_scrape_cc_tab(CC_UNBILLED_SHELL_URL, TAB_UNBILLED_SELECTOR, "NoFacturado")`.
+
+Inside `_scrape_cc_tab` for each CC URL:
+
+1. Navigate to the shell URL, run the pre-nav tour sweep.
+2. Resolve the inner content frame with `_get_stage_frame(CC_IFRAME_URL_FRAGMENT)`.
+3. Wait for the tab button (`TAB_BILLED_SELECTOR` / `TAB_UNBILLED_SELECTOR`),
+   defensively click it (no-op when already active), then wait for `CC_TABLE_NAC`.
+4. Extract the card id via `CC_CARD_LABEL_SELECTOR` and an XPath ancestor lookup against the surrounding `children-container`.
+5. **Nacional sub-tab** → `_select_cc_radio(SUBTAB_NACIONAL)` →
+   `_expand_all_ver_mas(anchor_selector=CC_TABLE_NAC)` → parse with
+   `CC_TABLE_NAC` / `CC_ROW` / `CC_CELL`.
+6. **Internacional sub-tab** → `_select_cc_radio(SUBTAB_INTERNAC)` →
+   wait for `CC_TABLE_INT` to become visible → `_expand_all_ver_mas(anchor_selector=CC_TABLE_INT)`
+   → parse with `CC_TABLE_INT` / `CC_ROW` / `CC_CELL`. Tolerates the table
+   never rendering (user has no USD movements).
+
+## Checking — "Saldos y últimos movimientos"
+
+```
+TABLE   = 'table.Table__dataTable'
+HEADERS = 'th.TableHead__headColumn'
+ROW     = 'tbody tr'
+CELL    = 'td.TableBody__cell'
+```
+
+7 columns; first (`id`) is hidden (`display:none`), last is a trailing action/icon cell — skip both.
+
+| idx | meaning     | header     | example          |
+|-----|-------------|------------|------------------|
+| 0   | id          | id (hidden)| `1351170312`     |
+| 1   | fecha       | Fecha      | `18-05-2026`     |
+| 2   | descripción | Descripción| `TEF X-X NOMBRE` |
+| 3   | ciudad      | Ciudad     | `SANTIAGO`       |
+| 4   | monto       | Monto      | varies           |
+| 5   | saldo       | Saldo      | varies           |
+| 6   | (action)    | (icon)     | empty            |
+
+Date format: `dd-mm-yyyy`.
+
+## Credit card (billed + unbilled, same MFE)
+
+```
+TAB_BILLED      = 'button#tab-action__movimientos-facturados'
+TAB_UNBILLED    = 'button#tab-action__movimientos-no-facturados'
+TAB_BALANCE     = 'button#tab-action__saldo'
+ACTIVE_TAB      = 'button[id^="tab-action__"].tab__action--active'
+
+# Sub-tabs are <button class="button button--tab tab__action"> — NOT radios.
+SUBTAB_NACIONAL = 'button.tab__action:has-text("Nacional"):not(:has-text("Internacional"))'
+SUBTAB_INTERNAC = 'button.tab__action:has-text("Internacional")'
+
+TABLE_NAC = 'div.tabla__movimientos--nacional table.table'
+TABLE_INT = 'div.tabla__movimientos--internacional table.table'
+HEAD      = 'thead.table__header tr.table__row th.table__header-item'
+ROW       = 'tbody tr.table__row'
+CELL      = 'td.table__data span'
+```
+
+⚠️ `.tab__action--active` is NOT unique (matches 2–3 nodes). Always combine with `id^="tab-action__"` to identify the relevant tab.
+
+⚠️ The Nacional/Internacional toggle is a sub-tab **button** (`button.tab__action`),
+NOT a radio input. Use `SUBTAB_NACIONAL` / `SUBTAB_INTERNAC`. The Nacional label
+appears in both buttons ("Nacional" and "Internacional"), so `SUBTAB_NACIONAL`
+uses `:has-text("Nacional"):not(:has-text("Internacional"))` to disambiguate.
+
+The portal renders only ~5 rows per sub-tab by default and appends a
+**"Ver más Movimientos facturados"** / **"Ver más Movimientos por facturar"**
+button below the table. This button MUST be clicked (and repeatedly clicked
+until exhausted) to load the full period — without it, the scraper silently
+drops everything past row 5.
+
+### Pagination
+
+`_expand_all_ver_mas` clicks any `button:has-text('Ver más Movimientos')` or
+`button:has-text('Ver más')` inside the active pane until none remain
+actionable (capped at 30 iterations to avoid loops). Each iteration scrolls
+the `anchor_selector` (`CC_TABLE_NAC` or `CC_TABLE_INT`) into view first so
+the section-specific button is mounted in the viewport before the click pass.
+Called once per sub-tab, after `_select_cc_radio` succeeds and before
+extraction.
+
+### Nacional columns
+
+| idx | meaning     | example          |
+|-----|-------------|------------------|
+| 0   | fecha       | `04/04/2026`     |
+| 1   | descripción | `PAGO EN EFECTIVO`, generic merchant names      |
+| 2   | ciudad      | `SANTIAGO` or blank `<span class="no-wrap"> </span>` |
+| 3   | monto       | `$-1.089.139` (abono) or `$205.813` (cargo) |
+| 4   | (icon)      | empty            |
+
+Date format: `dd/mm/yyyy`. **Sign convention:** negative = abono/payment (inverted vs accounting standard). Parser must invert if storing as `negative = spending`.
+
+### Internacional columns
+
+Headers: `FECHA, DESCRIPCIÓN, PAÍS, REFERENCIA, MONTO`.
+
+| idx | meaning     | notes                                              |
+|-----|-------------|----------------------------------------------------|
+| 0   | fecha       | `dd/mm/yyyy`                                       |
+| 1   | descripción | merchant name (USD-billed subscription/purchase)   |
+| 2   | país        | 2-letter code; may be blank                        |
+| 3   | referencia  | numeric (`-23,80`, `58,84`) — original ccy         |
+| 4   | monto       | currency-prefixed (`USD -23,80`) — NOT CLP        |
+
+⚠️ tbody includes summary rows (`TOTAL PAGOS`, `TOTAL COMPRAS`) with empty fecha cell — **filter rows where idx 0 is blank**.
+
+## Limitations
+
+The scraper was developed and live-tested against a single-product profile: one cuenta corriente and one Visa Enjoy credit card. As a result:
+
+- `CHECKING_SHELL_URL` hardcodes `?type=CTACTE`. Profiles with additional cuentas (other `CTACTE`, or `CTAH` / `CTANI` / `CTAV` variants) would be missed. To support them, read the account list on the checking shell and iterate `?type=CTACTE|CTAH|CTANI|CTAV` (and any future codes).
+- `CC_SHELL_URL` omits `card=NNNN`; the portal auto-picks the only card when there is one. Profiles with multiple cards would only return the default one. To support them, read the card dropdown inside the CC iframe and iterate `?card=NNNN`.
+
+No multi-account/multi-card selection logic is implemented or tested. PRs welcome — start in `ScotiabankScraper.scrape` and the URL constants near the top of the class.
+
+## Fixture placeholder conventions
+
+The committed HTML fixtures use the following placeholder values throughout
+so the per-cell extractors can be exercised without relying on any
+real-account data:
+
+- RUT → `12.345.678-9` (anywhere a RUT appears, including the `TEF ...`
+  description prefix).
+- Card last-4 → `****XXXX`.
+- Names → `NOMBRE APELLIDO`.
+- Long account numbers in `<td>` → `XXXXXXXXX`.
+- Amounts → round invented values (e.g. `$1.500`, `$25.000`, `$-10.000`).
+- Dates → invented `dd-mm-yyyy` / `dd/mm/yyyy` strings in 2026.

--- a/fintself/scrapers/__init__.py
+++ b/fintself/scrapers/__init__.py
@@ -11,6 +11,7 @@ from .cl import (
     BiceScraper,
     CencosudScraper,
     SantanderScraper,
+    ScotiabankScraper,
 )
 
 # Dictionary that maps bank IDs to scraper classes
@@ -20,6 +21,7 @@ _SCRAPERS: Dict[str, Type[BaseScraper]] = {
     "cl_banco_chile": BancoChileScraper,
     "cl_estado": BancoEstadoScraper,
     "cl_bice": BiceScraper,
+    "cl_scotiabank": ScotiabankScraper,
 }
 
 
@@ -68,6 +70,7 @@ def list_available_scrapers() -> Dict[str, str]:
         "cl_banco_chile": "Scraper for Banco de Chile (Chile).",
         "cl_estado": "Scraper for Cuenta RUT Banco Estado (Chile).",
         "cl_bice": "Scraper for Banco Bice (Chile).",
+        "cl_scotiabank": "Scraper for Scotiabank (Chile).",
     }
 
     return {

--- a/fintself/scrapers/base.py
+++ b/fintself/scrapers/base.py
@@ -10,7 +10,6 @@ from playwright.sync_api import (
     Locator,
     Page,
     Playwright,
-    sync_playwright,
 )
 from playwright.sync_api import (
     TimeoutError as PlaywrightTimeoutError,
@@ -66,6 +65,32 @@ class BaseScraper(ABC):
         self.page: Optional[Page] = None
         self.user: Optional[str] = None
         self.password: Optional[str] = None
+
+    def _playwright_factory(self):
+        """Return the `sync_playwright` callable. Override to use a fork
+        (e.g. `patchright.sync_api.sync_playwright`)."""
+        from playwright.sync_api import sync_playwright
+        return sync_playwright
+
+    def _browser_launch_kwargs(self) -> dict:
+        """Return kwargs for `chromium.launch()`. Default = legacy behavior."""
+        return {
+            "headless": self.headless,
+            "slow_mo": self.slow_mo,
+        }
+
+    def _browser_context_kwargs(self) -> dict:
+        """Return kwargs for `browser.new_context()`. Default = legacy behavior."""
+        return {
+            "user_agent": self.user_agent,
+            "viewport": self.viewport,
+            "locale": self.locale,
+            "timezone_id": self.timezone_id,
+        }
+
+    def _browser_init_script(self) -> Optional[str]:
+        """Return JS string for `page.add_init_script()`. Default = legacy one-liner."""
+        return "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"
 
     @abstractmethod
     def _get_bank_id(self) -> str:
@@ -327,26 +352,21 @@ class BaseScraper(ABC):
         self.user = user
         self.password = password
 
-        with sync_playwright() as p:
+        sync_playwright_fn = self._playwright_factory()
+        with sync_playwright_fn() as p:
             self.playwright = p
             try:
+                launch_kwargs = self._browser_launch_kwargs()
                 logger.info(
-                    f"Launching browser for {self._get_bank_id()} (headless: {self.headless})..."
+                    f"Launching browser for {self._get_bank_id()} "
+                    f"(headless: {launch_kwargs.get('headless')})..."
                 )
-                self.browser = self.playwright.chromium.launch(
-                    headless=self.headless, slow_mo=self.slow_mo
-                )
+                self.browser = self.playwright.chromium.launch(**launch_kwargs)
 
-                context_options = {
-                    "user_agent": self.user_agent,
-                    "viewport": self.viewport,
-                    "locale": self.locale,
-                    "timezone_id": self.timezone_id,
-                }
-                context = self.browser.new_context(**context_options)
-                context.add_init_script(
-                    "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"
-                )
+                context = self.browser.new_context(**self._browser_context_kwargs())
+                init_script = self._browser_init_script()
+                if init_script:
+                    context.add_init_script(init_script)
                 self.page = context.new_page()
                 self.page.set_default_timeout(self.default_timeout)
 

--- a/fintself/scrapers/cl/__init__.py
+++ b/fintself/scrapers/cl/__init__.py
@@ -6,6 +6,7 @@ from .bice import BiceScraper
 from .cencosud import CencosudScraper
 from .estado import BancoEstadoScraper
 from .santander import SantanderScraper
+from .scotiabank import ScotiabankScraper
 
 __all__ = [
     "BancoChileScraper",
@@ -13,4 +14,5 @@ __all__ = [
     "BiceScraper",
     "CencosudScraper",
     "SantanderScraper",
+    "ScotiabankScraper",
 ]

--- a/fintself/scrapers/cl/scotiabank.py
+++ b/fintself/scrapers/cl/scotiabank.py
@@ -129,6 +129,10 @@ class ScotiabankScraper(BaseScraper):
         ".modal button[aria-label='Cerrar']",
     ]
 
+    # Promotional modal on scotiabank.cl home (intermitente, intercepta 'Acceso Scotia')
+    HOME_PROMO_CLOSE_SELECTOR = "a.sc-itt-close-btn"
+    HOME_PROMO_TIMEOUT_MS = 5000
+
     def _get_bank_id(self) -> str:
         return "cl_scotiabank"
 
@@ -145,6 +149,7 @@ class ScotiabankScraper(BaseScraper):
         logger.info("Navigating to Scotiabank Chile home page.")
         self._navigate(self.HOME_URL, timeout_override=60000)
         self._save_debug_info("01_home_page")
+        self._dismiss_home_popup(page)
 
         logger.info("Opening 'Acceso Scotia' menu.")
         try:
@@ -249,6 +254,35 @@ class ScotiabankScraper(BaseScraper):
             page.wait_for_timeout(self.TOUR_POLL_INTERVAL_MS)
             elapsed += self.TOUR_POLL_INTERVAL_MS
         return False
+
+    def _dismiss_home_popup(self, page: Page) -> bool:
+        """Dismiss promotional modal that may appear on scotiabank.cl home.
+
+        Returns True if a popup was found and the close button was clicked,
+        False if no popup was detected within the timeout or the click failed.
+        Never raises — the login flow must continue regardless.
+        """
+        try:
+            page.wait_for_selector(
+                self.HOME_PROMO_CLOSE_SELECTOR,
+                state="visible",
+                timeout=self.HOME_PROMO_TIMEOUT_MS,
+            )
+        except PlaywrightTimeoutError:
+            logger.debug(
+                "[home] no promo popup detected within %dms",
+                self.HOME_PROMO_TIMEOUT_MS,
+            )
+            return False
+        try:
+            page.locator(self.HOME_PROMO_CLOSE_SELECTOR).first.click(timeout=2000)
+            logger.info("[home] dismissed promo popup")
+            self._save_debug_info("home_popup_dismissed")
+            return True
+        except Exception as exc:
+            logger.warning("[home] popup found but click failed: %s", exc)
+            self._save_debug_info("home_popup_click_failed")
+            return False
 
     # ─── Iframe routing ───────────────────────────────────────────────────
 

--- a/fintself/scrapers/cl/scotiabank.py
+++ b/fintself/scrapers/cl/scotiabank.py
@@ -155,8 +155,14 @@ class ScotiabankScraper(BaseScraper):
             timezone=self.timezone_id,
         )
 
-    def _browser_init_script(self) -> str:
-        return fingerprint.init_script()
+    def _browser_init_script(self) -> str | None:
+        # Workaround: patchright + real Chrome breaks DNS when add_init_script
+        # is invoked at context OR page level (any content, even empty).
+        # Patchright already patches navigator.webdriver via binary patches,
+        # so the core leak is covered without init_script. Other patches
+        # (chrome.runtime stub, languages enrichment, WebGL spoof) are
+        # deferred — apply post-navigation via page.evaluate if needed.
+        return None
 
     # ─── Login ────────────────────────────────────────────────────────────
 

--- a/fintself/scrapers/cl/scotiabank.py
+++ b/fintself/scrapers/cl/scotiabank.py
@@ -4,13 +4,14 @@ import re
 from decimal import Decimal
 from typing import List, Optional, Union
 
-from playwright.sync_api import Frame, FrameLocator, Locator, Page
-from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
-from playwright.sync_api import expect
+from patchright.sync_api import Frame, FrameLocator, Locator, Page
+from patchright.sync_api import TimeoutError as PlaywrightTimeoutError
+from patchright.sync_api import expect
 
 from fintself.core.exceptions import DataExtractionError, LoginError
 from fintself.core.models import MovementModel
 from fintself.scrapers.base import BaseScraper
+from fintself.utils import fingerprint
 from fintself.utils.logging import logger
 from fintself.utils.parsers import parse_chilean_amount, parse_chilean_date
 
@@ -135,6 +136,27 @@ class ScotiabankScraper(BaseScraper):
 
     def _get_bank_id(self) -> str:
         return "cl_scotiabank"
+
+    def _playwright_factory(self):
+        from patchright.sync_api import sync_playwright
+        return sync_playwright
+
+    def _browser_launch_kwargs(self) -> dict:
+        # If env forces headless explicit, honor it; otherwise auto by OS
+        from fintself import settings
+        explicit = settings.SCRAPER_HEADLESS_MODE
+        return fingerprint.browser_launch_kwargs(
+            headless=self.headless if explicit else None
+        )
+
+    def _browser_context_kwargs(self) -> dict:
+        return fingerprint.context_kwargs(
+            locale=self.locale,
+            timezone=self.timezone_id,
+        )
+
+    def _browser_init_script(self) -> str:
+        return fingerprint.init_script()
 
     # ─── Login ────────────────────────────────────────────────────────────
 

--- a/fintself/scrapers/cl/scotiabank.py
+++ b/fintself/scrapers/cl/scotiabank.py
@@ -1,0 +1,759 @@
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+from typing import List, Optional, Union
+
+from playwright.sync_api import Frame, FrameLocator, Locator, Page
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+from playwright.sync_api import expect
+
+from fintself.core.exceptions import DataExtractionError, LoginError
+from fintself.core.models import MovementModel
+from fintself.scrapers.base import BaseScraper
+from fintself.utils.logging import logger
+from fintself.utils.parsers import parse_chilean_amount, parse_chilean_date
+
+
+LocatorRoot = Union[Page, Frame, FrameLocator, Locator]
+
+
+class ScotiabankScraper(BaseScraper):
+    """Scraper to extract movements from Scotiabank Chile (personas).
+
+    Limitations:
+        Developed and live-tested against a single-product profile: one
+        cuenta corriente (CTACTE) and one Visa Enjoy credit card. The shell
+        URLs hardcode ``?type=CTACTE`` (``CHECKING_SHELL_URL``) and omit any
+        ``card=`` selector in ``CC_SHELL_URL``; the portal auto-picks the
+        only account/card when there is just one of each.
+
+        Users with multiple checking-style accounts (additional CTACTE, or
+        CTAH / CTANI / CTAV variants) or multiple credit cards would have
+        the extra products silently skipped — no selection step is
+        implemented. To add multi-product support, extend ``scrape`` to
+        read the account list and iterate ``?type=`` values, and read the
+        card dropdown inside ``CC_SHELL_URL`` to iterate ``?card=NNNN``
+        values. PRs welcome.
+    """
+
+    HOME_URL = "https://www.scotiabankchile.cl/"
+    LOGIN_URL_PREFIX = "https://banco.scotiabank.cl/mfe-login/scotia"
+    DASHBOARD_URL_FRAGMENT = "/mfe-home-cl/"
+
+    PUBLIC_LOGIN_TEXT = "Acceso Scotia"
+    PUBLIC_LOGIN_PERSONAS_NAME = "Ingreso Personas"
+
+    RUT_INPUT = '[data-testid="inputDni"]'
+    PASSWORD_INPUT = '[data-testid="inputPassword"]'
+    SUBMIT_BUTTON = 'role=button[name="Ingresar"]'
+
+    # Tab buttons inside the CC iframe (Saldo / Facturados / No facturados).
+    # `id` attributes are hash-free and stable; fallbacks via `id$=` cover
+    # a hypothetical schema rename.
+    TAB_BILLED_SELECTOR = (
+        "button#tab-action__movimientos-facturados, "
+        'button[id$="movimientos-facturados"]'
+    )
+    TAB_UNBILLED_SELECTOR = (
+        "button#tab-action__movimientos-no-facturados, "
+        'button[id$="movimientos-no-facturados"]'
+    )
+
+    # Sub-tab buttons inside the active CC pane (Facturados / No facturados).
+    # Portal renders <button class="button button--tab tab__action"> with
+    # text "Nacional"/"Nacionales" / "Internacional"/"Internacionales".
+    # NOT a radio input. Substring match handles both singular and plural.
+    SUBTAB_NACIONAL = (
+        'button.tab__action:has-text("Nacional"):not(:has-text("Internacional"))'
+    )
+    SUBTAB_INTERNAC = 'button.tab__action:has-text("Internacional")'
+
+    CHECKING_IFRAME_URL_FRAGMENT = "mfe-accounts-balancesmovements-web"
+    CC_IFRAME_URL_FRAGMENT = "mfe-simple-account-statement-web-cl"
+
+    SHELL_BASE = "https://www.scotiabank.cl/mfe/sweb/mfe-shell-web-cl/mfe/"
+    CHECKING_SHELL_URL = (
+        SHELL_BASE
+        + "mfe/ltmnsw/mfe-accounts-balancesmovements-web/?tab=saldos&type=CTACTE"
+    )
+    CC_BILLED_SHELL_URL = (
+        SHELL_BASE + "mfe-simple-account-statement-web-cl/?tab=movimientos-facturados"
+    )
+    CC_UNBILLED_SHELL_URL = (
+        SHELL_BASE
+        + "mfe-simple-account-statement-web-cl/?tab=movimientos-no-facturados"
+    )
+
+    # Checking table — primary uses BEM class names; `id="table-table"`
+    # is a stable fallback present on the actual data table.
+    CHECKING_TABLE = "table.Table__dataTable, table#table-table"
+    CHECKING_ROW = (
+        'tbody.TableBody tr.TableBody__bodyRow, #table-table tbody tr[class*="bodyRow"]'
+    )
+    CHECKING_CELL = "td.TableBody__cell, #table-table tbody td"
+
+    # Credit-card tables. `[class*="...nacional"]:not([class*="print"])`
+    # fallback survives a class-modifier rename.
+    CC_TABLE_NAC = (
+        "div.tabla__movimientos--nacional table.table, "
+        '[class*="movimientos--nacional"]:not([class*="print"]) table'
+    )
+    CC_TABLE_INT = (
+        "div.tabla__movimientos--internacional table.table, "
+        '[class*="movimientos--internacional"]:not([class*="print"]) table'
+    )
+    CC_ROW = "tbody tr.table__row"
+    CC_CELL = "td.table__data"
+
+    CC_CARD_LABEL_SELECTOR = "label.label__tarjetas-credito"
+
+    POST_LOGIN_SETTLE_MS = 8000
+    TOUR_POLL_INTERVAL_MS = 500
+    TOUR_PROBE_TIMEOUT_MS = 200
+    TOUR_PRE_NAV_MS = 500
+
+    IFRAME_WAIT_MS = 30000
+    TABLE_WAIT_MS = 20000
+
+    TOUR_DISMISS_SELECTORS = [
+        "button.driver-popover-close-btn",
+        ".driver-popover-close-btn",
+        "button:has-text('Saltar')",
+        "button:has-text('Omitir')",
+        "button:has-text('Entendido')",
+        "button:has-text('Finalizar tour')",
+        "button:has-text('Finalizar recorrido')",
+        "button:has-text('Listo')",
+        "[role='dialog'] button[aria-label='Cerrar']",
+        ".modal button[aria-label='Cerrar']",
+    ]
+
+    def _get_bank_id(self) -> str:
+        return "cl_scotiabank"
+
+    # ─── Login ────────────────────────────────────────────────────────────
+
+    def _login(self) -> None:
+        """Login to Scotiabank Chile personas portal."""
+        if not self.user or not self.password:
+            raise LoginError(
+                "CL_SCOTIABANK_USER and CL_SCOTIABANK_PASSWORD must be set."
+            )
+
+        page = self._ensure_page()
+        logger.info("Navigating to Scotiabank Chile home page.")
+        self._navigate(self.HOME_URL, timeout_override=60000)
+        self._save_debug_info("01_home_page")
+
+        logger.info("Opening 'Acceso Scotia' menu.")
+        try:
+            page.get_by_text(self.PUBLIC_LOGIN_TEXT).first.click(timeout=15000)
+        except PlaywrightTimeoutError:
+            self._save_debug_info("acceso_scotia_not_found")
+            raise LoginError("Could not find 'Acceso Scotia' on home page.")
+
+        logger.info("Clicking 'Ingreso Personas' link.")
+        try:
+            page.get_by_role("link", name=self.PUBLIC_LOGIN_PERSONAS_NAME).click(
+                timeout=15000
+            )
+        except PlaywrightTimeoutError:
+            self._save_debug_info("ingreso_personas_not_found")
+            raise LoginError("Could not find 'Ingreso Personas' link.")
+
+        logger.info("Waiting for login form to render.")
+        try:
+            page.wait_for_selector(self.RUT_INPUT, timeout=30000)
+        except PlaywrightTimeoutError:
+            self._save_debug_info("login_form_timeout")
+            raise LoginError("Login form did not render in time.")
+        self._save_debug_info("02_login_form")
+
+        logger.info("Entering credentials.")
+        self._type(self.RUT_INPUT, self.user, delay=120)
+        self._type(self.PASSWORD_INPUT, self.password, delay=120)
+        self._save_debug_info("03_credentials_entered")
+
+        logger.info("Submitting login form.")
+        self._click(self.SUBMIT_BUTTON)
+
+        logger.info("Waiting for post-login redirect.")
+        try:
+            expect(page).to_have_url(
+                re.compile(re.escape(self.DASHBOARD_URL_FRAGMENT)), timeout=45000
+            )
+            self._save_debug_info("04_login_success")
+            logger.info("Login to Scotiabank Chile successful.")
+        except (PlaywrightTimeoutError, AssertionError):
+            self._save_debug_info("post_login_error")
+            current_url = page.url
+            try:
+                body_snippet = page.content()[:1500].lower()
+            except Exception:
+                body_snippet = ""
+            if any(
+                kw in body_snippet
+                for kw in (
+                    "mantenimiento",
+                    "mantención",
+                    "mantencion",
+                    "fuera de servicio",
+                )
+            ):
+                raise LoginError(
+                    f"Scotiabank portal appears to be under maintenance "
+                    f"(url={current_url}). See debug_output/post_login_error_*."
+                )
+            raise LoginError(
+                f"Post-login redirect to {self.DASHBOARD_URL_FRAGMENT} did not "
+                f"happen within 45s (url={current_url}). Likely cause: invalid "
+                f"credentials or portal blocked the session. "
+                f"See debug_output/post_login_error_*."
+            )
+
+        self._dismiss_onboarding_tour(page)
+
+    def _dismiss_onboarding_tour(
+        self,
+        page: Page,
+        context: str = "post_login",
+        max_wait_ms: Optional[int] = None,
+    ) -> bool:
+        """Poll for and close the onboarding tour overlay.
+
+        Never matches 'Cerrar' alone (that is the logout button text).
+        Returns True if a tour button was dismissed, False otherwise.
+
+        ``max_wait_ms`` overrides the polling window — use a small value
+        (e.g. ``TOUR_PRE_NAV_MS``) when called right before a click to
+        avoid wasting time when no overlay is present. Default is the
+        post-login settle window.
+        """
+        budget = max_wait_ms if max_wait_ms is not None else self.POST_LOGIN_SETTLE_MS
+        elapsed = 0
+        while elapsed < max(budget, 1):
+            for sel in self.TOUR_DISMISS_SELECTORS:
+                try:
+                    loc = page.locator(sel).first
+                    if loc.is_visible(timeout=self.TOUR_PROBE_TIMEOUT_MS):
+                        logger.info(f"[{context}] dismissing tour overlay: {sel}")
+                        loc.click(timeout=2000)
+                        page.wait_for_timeout(300)
+                        self._save_debug_info(f"tour_dismissed_{context}")
+                        return True
+                except Exception:
+                    pass
+            if elapsed + self.TOUR_POLL_INTERVAL_MS >= budget:
+                break
+            page.wait_for_timeout(self.TOUR_POLL_INTERVAL_MS)
+            elapsed += self.TOUR_POLL_INTERVAL_MS
+        return False
+
+    # ─── Iframe routing ───────────────────────────────────────────────────
+
+    def _get_stage_frame(self, url_fragment: str) -> Frame:
+        """Return the iframe-stage ``Frame`` whose URL contains the fragment.
+
+        Waits up to ``IFRAME_WAIT_MS`` for the frame to attach with the right
+        URL, then returns it. Raises ``DataExtractionError`` on timeout.
+        """
+        page = self._ensure_page()
+        deadline_ms = self.IFRAME_WAIT_MS
+        elapsed = 0
+        interval = 500
+        last_urls: List[str] = []
+        while elapsed < deadline_ms:
+            matches = [f for f in page.frames if url_fragment in (f.url or "")]
+            # Require the INNER content frame (no `mfe-shell` segment) — the
+            # outer shell frame matches the fragment too but lacks the
+            # table DOM. Keep polling until the inner frame appears.
+            inner = [f for f in matches if "mfe-shell" not in (f.url or "")]
+            if inner:
+                return inner[-1]
+            last_urls = [f.url for f in page.frames if f.url]
+            page.wait_for_timeout(interval)
+            elapsed += interval
+        self._save_debug_info(f"iframe_missing_{url_fragment}")
+        logger.warning(f"Frames present at timeout for '{url_fragment}': {last_urls!r}")
+        raise DataExtractionError(
+            f"Could not locate iframe-stage frame with url fragment '{url_fragment}'."
+        )
+
+    # ─── Checking ─────────────────────────────────────────────────────────
+
+    def _scrape_checking(self) -> List[MovementModel]:
+        """Navigate to checking account view and extract movements."""
+        page = self._ensure_page()
+        logger.info("Navigating directly to checking shell URL.")
+        self._navigate(self.CHECKING_SHELL_URL, timeout_override=60000)
+        self._save_debug_info("checking_01_navigated")
+        self._dismiss_onboarding_tour(
+            page, context="pre_checking", max_wait_ms=self.TOUR_PRE_NAV_MS
+        )
+
+        frame = self._get_stage_frame(self.CHECKING_IFRAME_URL_FRAGMENT)
+        try:
+            frame.wait_for_selector(self.CHECKING_TABLE, timeout=self.TABLE_WAIT_MS)
+        except PlaywrightTimeoutError:
+            self._save_debug_info("checking_table_missing")
+            logger.warning(
+                "[checking] table did not render; assuming no movements "
+                "(empty account or selector change)."
+            )
+            return []
+        self._save_debug_info("checking_02_table_ready")
+
+        movements = self._extract_checking_movements(frame)
+        logger.info(f"Extracted {len(movements)} checking movements.")
+        return movements
+
+    def _extract_checking_movements(
+        self, root: LocatorRoot, account_id: Optional[str] = None
+    ) -> List[MovementModel]:
+        """Parse the 'Saldos y últimos movimientos' table inside ``root``."""
+        rows = root.locator(self.CHECKING_ROW).all()
+        logger.debug(f"Checking rows located: {len(rows)}")
+
+        movements: List[MovementModel] = []
+        for idx, row in enumerate(rows):
+            try:
+                cells = row.locator(self.CHECKING_CELL).all()
+                if len(cells) < 6:
+                    logger.debug(f"Skipping row {idx}: only {len(cells)} cells.")
+                    continue
+
+                date_str = cells[1].inner_text(timeout=5000).strip()
+                description = cells[2].inner_text(timeout=5000).strip()
+                city = cells[3].inner_text(timeout=5000).strip()
+                amount_str = cells[4].inner_text(timeout=5000).strip()
+                saldo_str = cells[5].inner_text(timeout=5000).strip()
+
+                parsed_date = parse_chilean_date(date_str)
+                if parsed_date is None:
+                    logger.warning(f"Row {idx}: unparseable date {date_str!r}.")
+                    continue
+
+                amount = parse_chilean_amount(amount_str)
+                if amount.is_zero():
+                    continue
+
+                movements.append(
+                    MovementModel(
+                        date=parsed_date,
+                        description=description,
+                        amount=amount,
+                        currency="CLP",
+                        transaction_type=("Abono" if amount > 0 else "Cargo"),
+                        account_id=account_id,
+                        account_type="corriente",
+                        raw_data={
+                            "date_str": date_str,
+                            "amount_str": amount_str,
+                            "city": city,
+                            "saldo_str": saldo_str,
+                        },
+                    )
+                )
+            except Exception as exc:
+                logger.warning(f"Failed to parse checking row {idx}: {exc}")
+                continue
+        return movements
+
+    # ─── Credit card ──────────────────────────────────────────────────────
+
+    def _scrape_credit_card_billed(self) -> List[MovementModel]:
+        return self._scrape_cc_tab(
+            shell_url=self.CC_BILLED_SHELL_URL,
+            tab_selector=self.TAB_BILLED_SELECTOR,
+            transaction_type="Facturado",
+            context="cc_billed",
+        )
+
+    def _scrape_credit_card_unbilled(self) -> List[MovementModel]:
+        return self._scrape_cc_tab(
+            shell_url=self.CC_UNBILLED_SHELL_URL,
+            tab_selector=self.TAB_UNBILLED_SELECTOR,
+            transaction_type="NoFacturado",
+            context="cc_unbilled",
+        )
+
+    def _scrape_cc_tab(
+        self,
+        *,
+        shell_url: str,
+        tab_selector: str,
+        transaction_type: str,
+        context: str,
+    ) -> List[MovementModel]:
+        """Navigate to the CC MFE shell URL for this tab and extract.
+
+        Each tab (facturados / no-facturados) has its own shell URL so
+        Playwright lands on a fresh iframe state. Falling back to a single
+        URL + tab click leaks the previous tab's DOM (both panes stay
+        mounted) and causes duplicate extractions.
+        """
+        page = self._ensure_page()
+        logger.info(f"[{context}] navigating directly to {shell_url}.")
+        self._navigate(shell_url, timeout_override=60000)
+        self._save_debug_info(f"{context}_01_navigated")
+        self._dismiss_onboarding_tour(
+            page, context=f"pre_{context}", max_wait_ms=self.TOUR_PRE_NAV_MS
+        )
+
+        frame = self._get_stage_frame(self.CC_IFRAME_URL_FRAGMENT)
+
+        # Tab is pre-selected by URL; if the button is rendered we still
+        # click it to be defensive (no-op if already active).
+        logger.info(f"[{context}] waiting for tab {tab_selector} to render.")
+        try:
+            frame.wait_for_selector(tab_selector, timeout=self.TABLE_WAIT_MS)
+        except PlaywrightTimeoutError:
+            self._save_debug_info(f"{context}_tab_missing")
+            raise DataExtractionError(
+                f"[{context}] tab {tab_selector} not present in iframe."
+            )
+        try:
+            frame.locator(tab_selector).click(timeout=3000)
+            logger.info(f"[{context}] tab clicked.")
+        except Exception as exc:
+            logger.info(f"[{context}] tab click skipped (already active?): {exc}")
+        try:
+            frame.wait_for_selector(self.CC_TABLE_NAC, timeout=self.TABLE_WAIT_MS)
+        except PlaywrightTimeoutError:
+            self._save_debug_info(f"{context}_nac_table_missing")
+            logger.warning(
+                f"[{context}] nacional table did not render; assuming empty period."
+            )
+            return []
+        self._save_debug_info(f"{context}_02_table_ready")
+
+        account_id = self._extract_card_id(frame)
+        movements: List[MovementModel] = []
+
+        # Nacional sub-tab (default-active in DOM) → expand → extract.
+        self._select_cc_radio(frame, self.SUBTAB_NACIONAL, "nacional", context)
+        self._expand_all_ver_mas(
+            frame,
+            context=f"{context}_nacional",
+            anchor_selector=self.CC_TABLE_NAC,
+        )
+        nac = self._extract_cc_nacional_movements(
+            frame, account_id=account_id, transaction_type=transaction_type
+        )
+        logger.info(f"[{context}] nacional rows: {len(nac)}.")
+        movements.extend(nac)
+
+        # Internacional sub-tab → SPA unhides the internacional table.
+        # Tolerate failure: user may not have USD movements.
+        if self._select_cc_radio(frame, self.SUBTAB_INTERNAC, "internacional", context):
+            try:
+                frame.wait_for_selector(
+                    self.CC_TABLE_INT, state="visible", timeout=5000
+                )
+            except PlaywrightTimeoutError:
+                logger.info(
+                    f"[{context}] internacional table did not render; "
+                    f"assuming no USD movements."
+                )
+                return movements
+            self._expand_all_ver_mas(
+                frame,
+                context=f"{context}_internacional",
+                anchor_selector=self.CC_TABLE_INT,
+            )
+            intl = self._extract_cc_internacional_movements(
+                frame, account_id=account_id, transaction_type=transaction_type
+            )
+            logger.info(f"[{context}] internacional rows: {len(intl)}.")
+            movements.extend(intl)
+
+        logger.info(f"[{context}] extracted {len(movements)} CC movements.")
+        return movements
+
+    def _expand_all_ver_mas(
+        self, frame: Frame, context: str, anchor_selector: Optional[str] = None
+    ) -> None:
+        """Click 'Ver más Movimientos' until exhausted (paginated panel).
+
+        Each click reveals more rows in the active CC pane. Buttons are
+        often off-screen and Playwright's ``is_visible`` returns False
+        for them, so we iterate ALL matching buttons by index, scroll
+        each into view, and click whatever becomes actionable. Capped at
+        30 iterations to avoid infinite loops.
+
+        ``anchor_selector`` (optional): scroll this element into view
+        before each pass so a section's own 'Ver más' button gets
+        mounted in the viewport.
+        """
+        button_selector = (
+            "button:has-text('Ver más Movimientos'), button:has-text('Ver más')"
+        )
+        clicks = 0
+        max_clicks = 30
+        row_selector = anchor_selector + " tbody tr" if anchor_selector else None
+        while clicks < max_clicks:
+            if anchor_selector:
+                try:
+                    anchor = frame.locator(anchor_selector).first
+                    if anchor.count() > 0:
+                        anchor.scroll_into_view_if_needed(timeout=1500)
+                except Exception:
+                    pass
+            rows_before = frame.locator(row_selector).count() if row_selector else None
+            buttons = frame.locator(button_selector)
+            count = buttons.count()
+            clicked = False
+            for i in range(count):
+                btn = buttons.nth(i)
+                try:
+                    btn.scroll_into_view_if_needed(timeout=1500)
+                    if not btn.is_visible(timeout=500):
+                        continue
+                    btn.click(timeout=3000)
+                    frame.wait_for_timeout(800)
+                    clicks += 1
+                    clicked = True
+                    break
+                except Exception as exc:
+                    logger.debug(
+                        f"[{context}] 'Ver más' button[{i}] skipped: "
+                        f"{type(exc).__name__}"
+                    )
+            if clicked and row_selector is not None:
+                rows_after = frame.locator(row_selector).count()
+                if rows_after <= rows_before:
+                    logger.info(
+                        f"[{context}] 'Ver más' click did not add rows "
+                        f"({rows_before} → {rows_after}); stopping."
+                    )
+                    break
+            if not clicked:
+                break
+        if clicks:
+            logger.info(f"[{context}] expanded 'Ver más' {clicks} time(s).")
+
+    def _select_cc_radio(
+        self, frame: Frame, radio_selector: str, label: str, context: str
+    ) -> bool:
+        """Click a CC radio toggle (Nacional / Internacional) inside the iframe.
+
+        Returns True if the click succeeded (or radio not present, treated
+        as "already in that view"); False only on hard failures.
+        """
+        try:
+            loc = frame.locator(radio_selector).first
+            if loc.count() == 0:
+                logger.info(
+                    f"[{context}] radio '{label}' not present; "
+                    f"assuming view already active."
+                )
+                return True
+            loc.scroll_into_view_if_needed(timeout=3000)
+            loc.click(timeout=5000)
+            # Wait for the SPA to swap the active panel's table; lazy
+            # renders may otherwise miss the last few rows.
+            frame.wait_for_timeout(2000)
+            logger.info(f"[{context}] selected '{label}' radio.")
+            self._save_debug_info(f"{context}_radio_{label}")
+            return True
+        except Exception as exc:
+            logger.warning(
+                f"[{context}] could not select '{label}' radio: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return False
+
+    def _extract_card_id(self, root: LocatorRoot) -> str:
+        """Best-effort extraction of card label (e.g. 'Visa Enjoy ****XXXX')."""
+        try:
+            label = root.locator(self.CC_CARD_LABEL_SELECTOR).first
+            container = label.locator(
+                "xpath=ancestor::*[contains(@class,'children-container')][1]"
+            )
+            value = container.locator("span").first.inner_text(timeout=3000).strip()
+            return value or "card_unknown"
+        except Exception:
+            try:
+                near = root.locator("span:has-text('Visa')").first
+                return near.inner_text(timeout=2000).strip() or "card_unknown"
+            except Exception:
+                return "card_unknown"
+
+    def _extract_cc_nacional_movements(
+        self,
+        root: LocatorRoot,
+        account_id: Optional[str],
+        transaction_type: str,
+    ) -> List[MovementModel]:
+        """Parse the national CC movement table.
+
+        Sign convention in the rendered DOM: negative = abono (payment),
+        positive = cargo (spending). The :class:`MovementModel` standard is
+        ``negative = outflow``, so we **invert** the parsed sign.
+        """
+        return self._extract_cc_rows(
+            root=root,
+            table_selector=self.CC_TABLE_NAC,
+            account_id=account_id,
+            transaction_type=transaction_type,
+            currency="CLP",
+            extract_currency_from_amount=False,
+            amount_col_idx=3,
+            location_col_idx=2,
+        )
+
+    def _extract_cc_internacional_movements(
+        self,
+        root: LocatorRoot,
+        account_id: Optional[str],
+        transaction_type: str,
+    ) -> List[MovementModel]:
+        """Parse the international CC table; preserves the per-row currency.
+
+        Row layout: fecha, descripción, país, referencia, monto (e.g.
+        ``USD -23,80``). Sign convention matches nacional (invert raw sign).
+        """
+        return self._extract_cc_rows(
+            root=root,
+            table_selector=self.CC_TABLE_INT,
+            account_id=account_id,
+            transaction_type=transaction_type,
+            currency="USD",
+            extract_currency_from_amount=True,
+            amount_col_idx=4,
+            location_col_idx=2,
+        )
+
+    def _extract_cc_rows(
+        self,
+        *,
+        root: LocatorRoot,
+        table_selector: str,
+        account_id: Optional[str],
+        transaction_type: str,
+        currency: str,
+        extract_currency_from_amount: bool,
+        amount_col_idx: int,
+        location_col_idx: int,
+    ) -> List[MovementModel]:
+        table = root.locator(table_selector).first
+        rows = table.locator(self.CC_ROW).all()
+        logger.debug(f"CC rows located in {table_selector}: {len(rows)}")
+
+        movements: List[MovementModel] = []
+        for idx, row in enumerate(rows):
+            try:
+                cells = row.locator(self.CC_CELL).all()
+                if len(cells) < 4:
+                    logger.debug(f"Skipping CC row {idx}: only {len(cells)} cells.")
+                    continue
+
+                date_str = self._clean_text(cells[0].inner_text(timeout=5000))
+                if not date_str:
+                    # Summary row (TOTAL PAGOS / TOTAL COMPRAS) — skip.
+                    continue
+
+                description = self._clean_text(cells[1].inner_text(timeout=5000))
+                location = (
+                    self._clean_text(cells[location_col_idx].inner_text(timeout=5000))
+                    if len(cells) > location_col_idx
+                    else ""
+                )
+                if len(cells) <= amount_col_idx:
+                    logger.debug(
+                        f"Skipping CC row {idx}: amount column {amount_col_idx} missing."
+                    )
+                    continue
+                amount_str = self._clean_text(
+                    cells[amount_col_idx].inner_text(timeout=5000)
+                )
+
+                parsed_date = parse_chilean_date(date_str)
+                if parsed_date is None:
+                    logger.warning(f"CC row {idx}: unparseable date {date_str!r}.")
+                    continue
+
+                row_currency = currency
+                if extract_currency_from_amount:
+                    m = re.match(r"\s*([A-Za-z]{3})\b", amount_str)
+                    if m:
+                        row_currency = m.group(1).upper()
+
+                amount_value = parse_chilean_amount(amount_str)
+                if amount_value.is_zero():
+                    continue
+
+                # Invert sign: raw "$-1.089.139" is an abono (payment); we
+                # store payments as positive (inflow) and cargos as negative.
+                amount_value = amount_value * Decimal("-1")
+                # Sanity check anchored at the start of the description so
+                # merchant tokens that contain "pago" as a substring don't
+                # trigger false positives.
+                if amount_value < 0 and re.match(
+                    r"^\s*(pago|abono|devoluci[óo]n)\b",
+                    description,
+                    re.IGNORECASE,
+                ):
+                    logger.warning(
+                        f"Sign-convention sanity warning: row {idx} description "
+                        f"{description[:40]!r} looks like a payment but mapped to a "
+                        f"negative amount ({amount_value}). Portal may have "
+                        f"inverted its sign convention."
+                    )
+
+                movements.append(
+                    MovementModel(
+                        date=parsed_date,
+                        description=description,
+                        amount=amount_value,
+                        currency=row_currency,
+                        transaction_type=transaction_type,
+                        account_id=account_id,
+                        account_type="credito",
+                        raw_data={
+                            "date_str": date_str,
+                            "amount_str": amount_str,
+                            "location": location,
+                            "table": table_selector,
+                        },
+                    )
+                )
+            except Exception as exc:
+                logger.warning(f"Failed to parse CC row {idx}: {exc}")
+                continue
+        return movements
+
+    @staticmethod
+    def _clean_text(text: Optional[str]) -> str:
+        return re.sub(r"\s+", " ", (text or "")).strip()
+
+    # ─── Orchestrator ─────────────────────────────────────────────────────
+
+    def _scrape_movements(self) -> List[MovementModel]:
+        """Orchestrate extraction of checking + credit card movements."""
+        logger.info("Starting Scotiabank Chile movement extraction.")
+        all_movements: List[MovementModel] = []
+
+        for label, fn in (
+            ("checking", self._scrape_checking),
+            ("cc_billed", self._scrape_credit_card_billed),
+            ("cc_unbilled", self._scrape_credit_card_unbilled),
+        ):
+            try:
+                all_movements.extend(fn())
+            except DataExtractionError as exc:
+                self._save_debug_info(f"{label}_extraction_failed")
+                logger.warning(f"[{label}] extraction failed: {exc}")
+            except Exception as exc:
+                self._save_debug_info(f"{label}_unexpected_error")
+                logger.exception(
+                    f"[{label}] unexpected error; other sections will continue: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+
+        logger.info(
+            f"Scotiabank Chile extraction finished. Total: {len(all_movements)} "
+            f"movements."
+        )
+        return all_movements

--- a/fintself/scrapers/cl/scotiabank.py
+++ b/fintself/scrapers/cl/scotiabank.py
@@ -142,12 +142,10 @@ class ScotiabankScraper(BaseScraper):
         return sync_playwright
 
     def _browser_launch_kwargs(self) -> dict:
-        # If env forces headless explicit, honor it; otherwise auto by OS
-        from fintself import settings
-        explicit = settings.SCRAPER_HEADLESS_MODE
-        return fingerprint.browser_launch_kwargs(
-            headless=self.headless if explicit else None
-        )
+        # Invisible via --headless=new by default. Debug mode -> visible window.
+        # debug_mode is set in BaseScraper.__init__ from settings.DEBUG env var.
+        headless = False if self.debug_mode else None
+        return fingerprint.browser_launch_kwargs(headless=headless)
 
     def _browser_context_kwargs(self) -> dict:
         return fingerprint.context_kwargs(

--- a/fintself/utils/fingerprint.py
+++ b/fintself/utils/fingerprint.py
@@ -44,3 +44,28 @@ def host_profile() -> dict:
         "arch": '"x86"',
         "is_mac": False,
     }
+
+
+def browser_launch_kwargs(*, headless: bool | None = None) -> dict:
+    """Return kwargs for `chromium.launch()`.
+
+    headless=None  -> auto: True on Linux, False on Darwin/Windows
+    headless=True  -> use --headless=new on Linux; no offscreen on mac
+    headless=False -> on mac, render offscreen via --window-position
+    """
+    sys = platform.system()
+    if headless is None:
+        headless = (sys == "Linux")
+
+    args = ["--disable-blink-features=AutomationControlled"]
+    if headless and sys == "Linux":
+        args.append("--headless=new")
+    elif not headless and sys == "Darwin":
+        args += ["--window-position=-2400,-2400", "--window-size=1440,900"]
+
+    return {
+        "channel": "chrome",
+        "headless": headless,
+        "args": args,
+        "ignore_default_args": ["--enable-automation"],
+    }

--- a/fintself/utils/fingerprint.py
+++ b/fintself/utils/fingerprint.py
@@ -1,0 +1,46 @@
+"""Host OS detection + browser/context/init-script config for stealth scraping.
+
+Pure module: no Playwright import. Returns dicts and strings only.
+"""
+from __future__ import annotations
+
+import platform
+
+CHROME_MAJOR = "131"
+CHROME_FULL = "131.0.6778.86"
+
+
+def host_profile() -> dict:
+    """Detect host OS, return a dict with consistent fingerprint dimensions."""
+    sysname = platform.system()
+    if sysname == "Darwin":
+        mac_v = platform.mac_ver()[0] or "15.0.0"
+        machine = platform.machine() or "arm64"
+        return {
+            "sysname": "Darwin",
+            "ua_os": "Macintosh; Intel Mac OS X 10_15_7",
+            "ch_platform": '"macOS"',
+            "ch_platform_version": f'"{mac_v}"',
+            "nav_platform": "MacIntel",
+            "arch": '"arm64"' if machine == "arm64" else '"x86"',
+            "is_mac": True,
+        }
+    if sysname == "Windows":
+        return {
+            "sysname": "Windows",
+            "ua_os": "Windows NT 10.0; Win64; x64",
+            "ch_platform": '"Windows"',
+            "ch_platform_version": '"15.0.0"',
+            "nav_platform": "Win32",
+            "arch": '"x86"',
+            "is_mac": False,
+        }
+    return {
+        "sysname": "Linux",
+        "ua_os": "X11; Linux x86_64",
+        "ch_platform": '"Linux"',
+        "ch_platform_version": '""',
+        "nav_platform": "Linux x86_64",
+        "arch": '"x86"',
+        "is_mac": False,
+    }

--- a/fintself/utils/fingerprint.py
+++ b/fintself/utils/fingerprint.py
@@ -49,23 +49,27 @@ def host_profile() -> dict:
 def browser_launch_kwargs(*, headless: bool | None = None) -> dict:
     """Return kwargs for `chromium.launch()`.
 
-    headless=None  -> auto: True on Linux, False on Darwin/Windows
-    headless=True  -> use --headless=new on Linux; no offscreen on mac
-    headless=False -> on mac, render offscreen via --window-position
+    headless=None  -> auto: invisible via --headless=new (no window, real engine)
+    headless=True  -> same as None (invisible via --headless=new)
+    headless=False -> visible window (debug only)
+
+    Critical pattern (plasticity / undetected):
+      To use --headless=new we pass `headless=False` to Playwright so it does
+      NOT inject the legacy `--headless` flag (detectable), then add
+      `--headless=new` manually to args. Result: full Chrome engine, no
+      visible window, fingerprint matches headed Chrome.
     """
-    sys = platform.system()
-    if headless is None:
-        headless = (sys == "Linux")
+    invisible = True if headless is None else headless
 
     args = ["--disable-blink-features=AutomationControlled"]
-    if headless and sys == "Linux":
+    if invisible:
         args.append("--headless=new")
-    elif not headless and sys == "Darwin":
-        args += ["--window-position=-2400,-2400", "--window-size=1440,900"]
 
     return {
         "channel": "chrome",
-        "headless": headless,
+        # Always False so Playwright won't inject legacy --headless.
+        # Invisibility comes from --headless=new in args instead.
+        "headless": False,
         "args": args,
         "ignore_default_args": ["--enable-automation"],
     }

--- a/fintself/utils/fingerprint.py
+++ b/fintself/utils/fingerprint.py
@@ -69,3 +69,35 @@ def browser_launch_kwargs(*, headless: bool | None = None) -> dict:
         "args": args,
         "ignore_default_args": ["--enable-automation"],
     }
+
+
+def context_kwargs(*, locale: str = "es-CL",
+                   timezone: str = "America/Santiago") -> dict:
+    """Return kwargs for `browser.new_context()` with OS-consistent fingerprint."""
+    p = host_profile()
+    ua = (f"Mozilla/5.0 ({p['ua_os']}) AppleWebKit/537.36 "
+          f"(KHTML, like Gecko) Chrome/{CHROME_FULL} Safari/537.36")
+    is_mac = p["is_mac"]
+    viewport = {"width": 1440, "height": 900} if is_mac \
+        else {"width": 1536, "height": 864}
+    return {
+        "user_agent": ua,
+        "locale": locale,
+        "timezone_id": timezone,
+        "viewport": viewport,
+        "screen": viewport,
+        "device_scale_factor": 2 if is_mac else 1,
+        "is_mobile": False,
+        "has_touch": False,
+        "color_scheme": "light",
+        "extra_http_headers": {
+            "sec-ch-ua": (f'"Chromium";v="{CHROME_MAJOR}", '
+                          f'"Google Chrome";v="{CHROME_MAJOR}", '
+                          f'"Not_A Brand";v="24"'),
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": p["ch_platform"],
+            "sec-ch-ua-platform-version": p["ch_platform_version"],
+            "sec-ch-ua-arch": p["arch"],
+            "accept-language": "es-CL,es;q=0.9,en;q=0.8",
+        },
+    }

--- a/fintself/utils/fingerprint.py
+++ b/fintself/utils/fingerprint.py
@@ -101,3 +101,62 @@ def context_kwargs(*, locale: str = "es-CL",
             "accept-language": "es-CL,es;q=0.9,en;q=0.8",
         },
     }
+
+
+def init_script() -> str:
+    """Return a JS string to inject via `page.add_init_script()` for stealth."""
+    p = host_profile()
+    is_mac = p["is_mac"]
+    webgl_vendor = "Google Inc. (Apple)" if is_mac else "Google Inc. (Intel)"
+    webgl_renderer = (
+        "ANGLE (Apple, ANGLE Metal Renderer: Apple M1, Unspecified Version)"
+        if is_mac
+        else "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)"
+    )
+    hw_concurrency = 8 if is_mac else 12
+    return f"""
+Object.defineProperty(navigator, 'webdriver', {{ get: () => undefined }});
+Object.defineProperty(navigator, 'platform', {{ get: () => '{p["nav_platform"]}' }});
+Object.defineProperty(navigator, 'languages', {{ get: () => ['es-CL', 'es', 'en'] }});
+Object.defineProperty(navigator, 'hardwareConcurrency', {{ get: () => {hw_concurrency} }});
+Object.defineProperty(navigator, 'deviceMemory', {{ get: () => 8 }});
+Object.defineProperty(navigator, 'maxTouchPoints', {{ get: () => 0 }});
+
+if (typeof window.chrome === 'undefined' || !window.chrome.runtime) {{
+    window.chrome = window.chrome || {{}};
+    window.chrome.runtime = window.chrome.runtime || {{}};
+    window.chrome.loadTimes = window.chrome.loadTimes || (() => ({{}}));
+    window.chrome.csi = window.chrome.csi || (() => ({{}}));
+}}
+
+const _origGetParameter = WebGLRenderingContext.prototype.getParameter;
+WebGLRenderingContext.prototype.getParameter = function(param) {{
+    if (param === 37445) return '{webgl_vendor}';
+    if (param === 37446) return '{webgl_renderer}';
+    return _origGetParameter.call(this, param);
+}};
+if (typeof WebGL2RenderingContext !== 'undefined') {{
+    WebGL2RenderingContext.prototype.getParameter = WebGLRenderingContext.prototype.getParameter;
+}}
+
+const _origQuery = navigator.permissions.query.bind(navigator.permissions);
+navigator.permissions.query = (descriptor) => (
+    descriptor && descriptor.name === 'notifications'
+        ? Promise.resolve({{ state: Notification.permission }})
+        : _origQuery(descriptor)
+);
+
+if (navigator.userAgentData && navigator.userAgentData.getHighEntropyValues) {{
+    const _origHE = navigator.userAgentData.getHighEntropyValues.bind(navigator.userAgentData);
+    navigator.userAgentData.getHighEntropyValues = (hints) => Promise.resolve({{
+        platform: {p["ch_platform"]},
+        platformVersion: {p["ch_platform_version"]},
+        architecture: {p["arch"]},
+        bitness: "64",
+        model: "",
+        mobile: false,
+        uaFullVersion: "{CHROME_FULL}",
+        brands: navigator.userAgentData.brands,
+    }});
+}}
+""".strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pandas>=2.3.1",
     "python-dotenv>=1.1.1",
     "playwright>=1.42.0",
+    "patchright>=1.49.0",
     "pydantic>=2.11.7",
     "typer>=0.16.0",
 ]

--- a/scripts/verify_fingerprint.py
+++ b/scripts/verify_fingerprint.py
@@ -1,0 +1,37 @@
+"""Manual verifier: launch a stealth browser, hit sannysoft + creepjs,
+save screenshots, print URLs. Run via:
+
+    uv run python scripts/verify_fingerprint.py
+
+Then open /tmp/sannysoft.png and /tmp/creepjs.png to inspect.
+"""
+from patchright.sync_api import sync_playwright
+
+from fintself.utils import fingerprint
+
+
+def main() -> int:
+    with sync_playwright() as p:
+        browser = p.chromium.launch(**fingerprint.browser_launch_kwargs())
+        ctx = browser.new_context(**fingerprint.context_kwargs())
+        ctx.add_init_script(fingerprint.init_script())
+        page = ctx.new_page()
+        page.set_default_timeout(30000)
+
+        print("Loading bot.sannysoft.com ...")
+        page.goto("https://bot.sannysoft.com/")
+        page.wait_for_timeout(2000)
+        page.screenshot(path="/tmp/sannysoft.png", full_page=True)
+
+        print("Loading creepjs ...")
+        page.goto("https://abrahamjuliot.github.io/creepjs/")
+        page.wait_for_timeout(10000)
+        page.screenshot(path="/tmp/creepjs.png", full_page=True)
+
+        browser.close()
+    print("Screenshots saved: /tmp/sannysoft.png, /tmp/creepjs.png")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Shared pytest fixtures for fintself tests."""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+from playwright.sync_api import Browser, Page, sync_playwright
+
+
+@pytest.fixture(scope="session")
+def _playwright() -> Iterator:
+    with sync_playwright() as p:
+        yield p
+
+
+@pytest.fixture(scope="session")
+def chromium_browser(_playwright) -> Iterator[Browser]:
+    browser = _playwright.chromium.launch(headless=True)
+    try:
+        yield browser
+    finally:
+        browser.close()
+
+
+@pytest.fixture
+def fixture_page(chromium_browser: Browser) -> Iterator[Page]:
+    """A fresh Playwright page per test; load fixture HTML via ``page.set_content``."""
+    ctx = chromium_browser.new_context(locale="es-CL")
+    page = ctx.new_page()
+    try:
+        yield page
+    finally:
+        ctx.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Iterator
 
 import pytest
-from playwright.sync_api import Browser, Page, sync_playwright
+from patchright.sync_api import Browser, Page, sync_playwright
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures/cl/scotiabank/README.md
+++ b/tests/fixtures/cl/scotiabank/README.md
@@ -1,0 +1,53 @@
+# Scotiabank Chile — fixtures
+
+Hand-crafted HTML mirroring the DOM that `ScotiabankScraper` reads. Used by
+the fixture-driven tests in `tests/scrapers/cl/test_scotiabank.py`. All
+identifying values follow the placeholder conventions in `CONTRIBUTING.md`.
+
+| File | Origin URL fragment | Last updated | What it represents |
+|------|---------------------|--------------|--------------------|
+| `login_page.html` | `banco.scotiabank.cl/mfe-login/scotia` | 2026-05-16 | Anonymous public SPA login form. No auth required to view. |
+| `checking_movements.html` | `mfe/ltmnsw/mfe-accounts-balancesmovements-web/?tab=saldos&type=CTACTE` | 2026-05-16 | Iframe content for "Saldos y últimos movimientos" of a cuenta corriente. Table class `Table__dataTable`; cells `TableBody__cell`. Date format `dd-mm-yyyy`. |
+| `credit_card_billed.html` | `mfe-simple-account-statement-web-cl/?tab=movimientos-facturados` | 2026-05-16 | Iframe content with **Movimientos facturados** tab active. Contains nacional + internacional tables (`tabla__movimientos--nacional`, `tabla__movimientos--internacional`), already fully expanded. |
+| `credit_card_unbilled.html` | `mfe-simple-account-statement-web-cl/?tab=movimientos-no-facturados` | 2026-05-16 | Same iframe but with **Movimientos por facturar** tab active. Same table classes; different `tab__action--active` placement. Also fully expanded. |
+
+## What the live run reads beyond these fixtures
+
+The captured DOM is a post-expansion, post-sub-tab-switch snapshot. Several
+moving parts of `ScotiabankScraper` therefore have **no fixture coverage** and
+are only exercised in live runs:
+
+- **`_expand_all_ver_mas` pagination.** Both CC fixtures already contain the
+  fully expanded tables (no `Ver más Movimientos facturados` / `Ver más
+  Movimientos por facturar` button remains in the saved HTML). The click loop,
+  the 30-iteration cap, and the `anchor_selector` scroll-into-view behavior
+  are not triggered by the fixture tests.
+- **Nacional/Internacional sub-tab switch.** `SUBTAB_NACIONAL` and
+  `SUBTAB_INTERNAC` are clicked at runtime to unhide each pane, but the
+  saved HTML already has both `div.tabla__movimientos--nacional` and
+  `div.tabla__movimientos--internacional` tables present and parseable.
+  `_select_cc_radio` itself is not exercised here.
+- **`_get_stage_frame` inner-frame filtering.** The fixtures are dumps of the
+  inner content frame only; the outer `mfe-shell` wrapper that also matches
+  the URL fragment is not present in the saved HTML. The filter that excludes
+  frames whose URL contains `mfe-shell` is therefore only validated live.
+
+Regressions in any of the above will pass the fixture suite and only surface
+in `scripts/run_all_scrapers_visible.py` against a real session.
+
+## Sign conventions
+
+- **Checking** (`checking_movements.html`): amounts in a dedicated column; sign follows the standard convention.
+- **CC nacional**: amount column displays a leading minus for an abono/payment and no sign for a cargo/spending (inverted vs the typical accounting convention). Parser must invert if storing as `negative = spending`.
+
+## Important parsing notes
+
+- Both CC tables include summary rows (`TOTAL PAGOS`, `TOTAL COMPRAS`) with an empty fecha cell — filter out rows where the first cell is blank.
+- Checking table has 7 columns; index 0 is hidden (`display: none`) and index 6 is a trailing action/icon cell — skip both when parsing.
+- For CC internacional, the "MONTO" column shows currency-prefixed values (e.g. `USD -23,80`) — preserve currency separately from the number.
+
+See `recon/scotiabank_notes.md` (gitignored) for the full selector documentation and the manual capture flow.
+
+## Source profile caveat
+
+These fixtures describe a single-product profile: one cuenta corriente (CTACTE) and one credit card. Because the portal auto-selects the only available product, the captured DOM does not include the multi-account or multi-card selectors (no `?type=` switcher UI, no `card=NNNN` dropdown). Profiles with multiple products would need additional fixtures to cover the selection step.

--- a/tests/fixtures/cl/scotiabank/checking_movements.html
+++ b/tests/fixtures/cl/scotiabank/checking_movements.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Scotiabank Checking — Test Fixture</title>
+
+</head>
+<body>
+<table class="Table__dataTable" id="table-table">
+  <thead>
+    <tr>
+      <th class="TableHead__headColumn" style="display: none;">id</th>
+      <th class="TableHead__headColumn">Fecha</th>
+      <th class="TableHead__headColumn">Descripción</th>
+      <th class="TableHead__headColumn">Ciudad</th>
+      <th class="TableHead__headColumn">Monto</th>
+      <th class="TableHead__headColumn">Saldo</th>
+      <th class="TableHead__headColumn TableHead__headColumn--center"></th>
+    </tr>
+  </thead>
+  <tbody class="TableBody">
+    <tr class="TableBody__bodyRow TableBody__bodyRow--striped">
+      <td class="TableBody__cell" style="display: none; justify-content: unset;">XXXXXXXXX</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;">15-04-2026</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 4;">TEF 12.345.678-9 NOMBRE APELLIDO</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;">SANTIAGO</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;"><p class="TableData__amount" aria-label="$1.500">$1.500</p></td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 1;"><p class="TableData__amount" aria-label="$101.500">$101.500</p></td>
+      <td class="TableBody__cell" style="justify-content: center; flex-grow: 1;"></td>
+    </tr>
+    <tr class="TableBody__bodyRow TableBody__bodyRow--striped">
+      <td class="TableBody__cell" style="display: none; justify-content: unset;">XXXXXXXXX</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;">14-04-2026</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 4;">PAGO POR WEB DE ELECTRICA EJEMPLO</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;">SANTIAGO</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;"><p class="TableData__amount" aria-label="$-20.000">$-20.000</p></td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 1;"><p class="TableData__amount" aria-label="$100.000">$100.000</p></td>
+      <td class="TableBody__cell" style="justify-content: center; flex-grow: 1;"></td>
+    </tr>
+    <tr class="TableBody__bodyRow TableBody__bodyRow--striped">
+      <td class="TableBody__cell" style="display: none; justify-content: unset;">XXXXXXXXX</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;">13-04-2026</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 4;">COMPRA TIENDA EJEMPLO</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;">SANTIAGO</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;"><p class="TableData__amount" aria-label="$-15.000">$-15.000</p></td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 1;"><p class="TableData__amount" aria-label="$120.000">$120.000</p></td>
+      <td class="TableBody__cell" style="justify-content: center; flex-grow: 1;"></td>
+    </tr>
+    <tr class="TableBody__bodyRow TableBody__bodyRow--striped">
+      <td class="TableBody__cell" style="display: none; justify-content: unset;">XXXXXXXXX</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;">12-04-2026</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 4;">TEF 12.345.678-9 NOMBRE APELLIDO</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;">SANTIAGO</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;"><p class="TableData__amount" aria-label="$50.000">$50.000</p></td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 1;"><p class="TableData__amount" aria-label="$135.000">$135.000</p></td>
+      <td class="TableBody__cell" style="justify-content: center; flex-grow: 1;"></td>
+    </tr>
+    <tr class="TableBody__bodyRow TableBody__bodyRow--striped">
+      <td class="TableBody__cell" style="display: none; justify-content: unset;">XXXXXXXXX</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;">11-04-2026</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 4;">PAGO POR WEB DE INTERNET EJEMPLO</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;">SANTIAGO</td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 2;"><p class="TableData__amount" aria-label="$-30.000">$-30.000</p></td>
+      <td class="TableBody__cell" style="justify-content: unset; flex-grow: 1;"><p class="TableData__amount" aria-label="$85.000">$85.000</p></td>
+      <td class="TableBody__cell" style="justify-content: center; flex-grow: 1;"></td>
+    </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/tests/fixtures/cl/scotiabank/credit_card_billed.html
+++ b/tests/fixtures/cl/scotiabank/credit_card_billed.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Scotiabank CC Billed — Test Fixture</title>
+
+</head>
+<body>
+<div class="cc-wrapper">
+  <label class="label__tarjetas-credito">Tarjeta de Crédito</label>
+  <div class="DataPairLayout_children-container__test">
+    <span class="Typography_content-data">Visa Ejemplo ****XXXX</span>
+  </div>
+
+  <div class="tab__bar">
+    <ul class="tab__list">
+      <li class="tab__item">
+        <button id="tab-action__saldo" class="button button--tab tab__action">Saldo</button>
+      </li>
+      <li class="tab__item">
+        <button id="tab-action__movimientos-facturados" class="button button--tab tab__action tab__action--active">Movimientos facturados</button>
+      </li>
+      <li class="tab__item">
+        <button id="tab-action__movimientos-no-facturados" class="button button--tab tab__action">Movimientos por facturar</button>
+      </li>
+    </ul>
+  </div>
+
+  <div class="tab__content tab__content--active">
+    <div class="cc-subtabs">
+      <button class="button button--tab tab__action tab__action--active">Nacional</button>
+      <button class="button button--tab tab__action">Internacional</button>
+    </div>
+
+    <div class="tabla__movimientos--nacional">
+      <div class="overflow-x">
+        <table class="table">
+          <thead class="table__header">
+            <tr class="table__row">
+              <th class="table__header-item"><span>FECHA</span></th>
+              <th class="table__header-item"><span>DESCRIPCIÓN</span></th>
+              <th class="table__header-item"><span>CIUDAD</span></th>
+              <th class="table__header-item"><span>MONTO</span></th>
+              <th class="table__header-item"><span></span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="table__row">
+              <td class="table__data"><span>01/03/2026</span></td>
+              <td class="table__data"><span>PAGO EN EFECTIVO</span></td>
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+              <td class="table__data"><span>$-100.000</span></td>
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span>05/03/2026</span></td>
+              <td class="table__data"><span>TIENDA EJEMPLO</span></td>
+              <td class="table__data"><span>SANTIAGO</span></td>
+              <td class="table__data"><span>$25.000</span></td>
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span>10/03/2026</span></td>
+              <td class="table__data"><span>RESTAURANTE TEST</span></td>
+              <td class="table__data"><span>SANTIAGO</span></td>
+              <td class="table__data"><span>$8.500</span></td>
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span>15/03/2026</span></td>
+              <td class="table__data"><span>COMBUSTIBLE EJEMPLO</span></td>
+              <td class="table__data"><span>SANTIAGO</span></td>
+              <td class="table__data"><span>$40.000</span></td>
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span>20/03/2026</span></td>
+              <td class="table__data"><span>FARMACIA EJEMPLO</span></td>
+              <td class="table__data"><span>SANTIAGO</span></td>
+              <td class="table__data"><span>$5.000</span></td>
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <button class="button">Ver más Movimientos facturados</button>
+
+    <div class="tabla__movimientos--internacional">
+      <div class="overflow-x">
+        <table class="table">
+          <thead class="table__header">
+            <tr class="table__row">
+              <th class="table__header-item"><span>FECHA</span></th>
+              <th class="table__header-item"><span>DESCRIPCIÓN</span></th>
+              <th class="table__header-item"><span>PAÍS</span></th>
+              <th class="table__header-item"><span>REFERENCIA</span></th>
+              <th class="table__header-item"><span>MONTO</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="table__row">
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+              <td class="table__data"><span>TOTAL PAGOS</span></td>
+              <td class="table__data"><span>00</span></td>
+              <td class="table__data"><span>0</span></td>
+              <td class="table__data"><span>USD 0,00</span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span>02/03/2026</span></td>
+              <td class="table__data"><span>PAGO EN EFECTIVO</span></td>
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+              <td class="table__data"><span>-10,00</span></td>
+              <td class="table__data"><span>USD -10,00</span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+              <td class="table__data"><span>TOTAL COMPRAS</span></td>
+              <td class="table__data"><span>00</span></td>
+              <td class="table__data"><span>0</span></td>
+              <td class="table__data"><span>USD 0,00</span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span>06/03/2026</span></td>
+              <td class="table__data"><span>STREAMING SERVICE</span></td>
+              <td class="table__data"><span>US</span></td>
+              <td class="table__data"><span>12,50</span></td>
+              <td class="table__data"><span>USD 12,50</span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span>11/03/2026</span></td>
+              <td class="table__data"><span>SOFTWARE TOOL EJEMPLO</span></td>
+              <td class="table__data"><span>US</span></td>
+              <td class="table__data"><span>25,00</span></td>
+              <td class="table__data"><span>USD 25,00</span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+              <td class="table__data"><span>COMISIONES, OTROS CARGOS Y AB</span></td>
+              <td class="table__data"><span>00</span></td>
+              <td class="table__data"><span>0</span></td>
+              <td class="table__data"><span>USD 0,00</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="tab__content">
+    <!-- "por facturar" pane (empty here; see credit_card_unbilled.html) -->
+  </div>
+</div>
+</body>
+</html>

--- a/tests/fixtures/cl/scotiabank/credit_card_unbilled.html
+++ b/tests/fixtures/cl/scotiabank/credit_card_unbilled.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Scotiabank CC Unbilled — Test Fixture</title>
+
+</head>
+<body>
+<div class="cc-wrapper">
+  <label class="label__tarjetas-credito">Tarjeta de Crédito</label>
+  <div class="DataPairLayout_children-container__test">
+    <span class="Typography_content-data">Visa Ejemplo ****XXXX</span>
+  </div>
+
+  <div class="tab__bar">
+    <ul class="tab__list">
+      <li class="tab__item">
+        <button id="tab-action__saldo" class="button button--tab tab__action">Saldo</button>
+      </li>
+      <li class="tab__item">
+        <button id="tab-action__movimientos-facturados" class="button button--tab tab__action">Movimientos facturados</button>
+      </li>
+      <li class="tab__item">
+        <button id="tab-action__movimientos-no-facturados" class="button button--tab tab__action tab__action--active">Movimientos por facturar</button>
+      </li>
+    </ul>
+  </div>
+
+  <div class="tab__content">
+    <!-- facturados pane (inactive in this fixture) -->
+  </div>
+
+  <div class="tab__content tab__content--active">
+    <div class="cc-subtabs">
+      <button class="button button--tab tab__action tab__action--active">Nacional</button>
+      <button class="button button--tab tab__action">Internacional</button>
+    </div>
+
+    <div class="tabla__movimientos--nacional">
+      <div class="overflow-x">
+        <table class="table">
+          <thead class="table__header">
+            <tr class="table__row">
+              <th class="table__header-item"><span>FECHA</span></th>
+              <th class="table__header-item"><span>DESCRIPCIÓN</span></th>
+              <th class="table__header-item"><span>CIUDAD</span></th>
+              <th class="table__header-item"><span>MONTO</span></th>
+              <th class="table__header-item"><span></span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="table__row">
+              <td class="table__data"><span>02/04/2026</span></td>
+              <td class="table__data"><span>SUPERMERCADO EJEMPLO</span></td>
+              <td class="table__data"><span>SANTIAGO</span></td>
+              <td class="table__data"><span>$18.000</span></td>
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span>05/04/2026</span></td>
+              <td class="table__data"><span>TRANSPORTE EJEMPLO</span></td>
+              <td class="table__data"><span>SANTIAGO</span></td>
+              <td class="table__data"><span>$3.500</span></td>
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span>07/04/2026</span></td>
+              <td class="table__data"><span>LIBRERIA EJEMPLO</span></td>
+              <td class="table__data"><span>SANTIAGO</span></td>
+              <td class="table__data"><span>$12.000</span></td>
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <button class="button">Ver más Movimientos por facturar</button>
+
+    <div class="tabla__movimientos--internacional">
+      <div class="overflow-x">
+        <table class="table">
+          <thead class="table__header">
+            <tr class="table__row">
+              <th class="table__header-item"><span>FECHA</span></th>
+              <th class="table__header-item"><span>DESCRIPCIÓN</span></th>
+              <th class="table__header-item"><span>PAÍS</span></th>
+              <th class="table__header-item"><span>REFERENCIA</span></th>
+              <th class="table__header-item"><span>MONTO</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="table__row">
+              <td class="table__data"><span><span class="no-wrap"> </span></span></td>
+              <td class="table__data"><span>TOTAL PAGOS</span></td>
+              <td class="table__data"><span>00</span></td>
+              <td class="table__data"><span>0</span></td>
+              <td class="table__data"><span>USD 0,00</span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span>03/04/2026</span></td>
+              <td class="table__data"><span>SUSCRIPCION EJEMPLO</span></td>
+              <td class="table__data"><span>US</span></td>
+              <td class="table__data"><span>9,99</span></td>
+              <td class="table__data"><span>USD 9,99</span></td>
+            </tr>
+            <tr class="table__row">
+              <td class="table__data"><span>08/04/2026</span></td>
+              <td class="table__data"><span>SERVICIO ONLINE EJEMPLO</span></td>
+              <td class="table__data"><span>US</span></td>
+              <td class="table__data"><span>14,50</span></td>
+              <td class="table__data"><span>USD 14,50</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/fixtures/cl/scotiabank/home_with_popup.html
+++ b/tests/fixtures/cl/scotiabank/home_with_popup.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Scotiabank Chile (test fixture)</title>
+  <style>
+    .sc-itt-promo-overlay {
+      position: fixed; inset: 0;
+      background: rgba(0,0,0,0.5);
+      z-index: 9999;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .sc-itt-promo-modal {
+      background: white; padding: 24px; border-radius: 8px;
+      position: relative; min-width: 320px;
+    }
+    a.sc-itt-close-btn {
+      position: absolute; top: 8px; right: 8px;
+      width: 24px; height: 24px;
+      display: inline-block;
+      cursor: pointer;
+      background: #333;
+    }
+  </style>
+</head>
+<body>
+  <div class="sc-itt-promo-overlay">
+    <div class="sc-itt-promo-modal">
+      <a class="sc-itt-close-btn iconcanvas-icon-close" href="#"></a>
+      <p>Promotional content placeholder</p>
+    </div>
+  </div>
+  <header>
+    <a href="/acceso-scotia">Acceso Scotia</a>
+  </header>
+</body>
+</html>

--- a/tests/fixtures/cl/scotiabank/home_without_popup.html
+++ b/tests/fixtures/cl/scotiabank/home_without_popup.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Scotiabank Chile (test fixture)</title>
+</head>
+<body>
+  <header>
+    <a href="/acceso-scotia">Acceso Scotia</a>
+  </header>
+</body>
+</html>

--- a/tests/fixtures/cl/scotiabank/login_page.html
+++ b/tests/fixtures/cl/scotiabank/login_page.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Scotiabank — Login</title>
+</head>
+<body>
+<form id="login-form" novalidate>
+  <label for="inputDni">Ingresa tu RUT</label>
+  <input id="inputDni" data-testid="inputDni" name="dni" type="text" placeholder="12.345.678-9">
+
+  <label for="inputPassword">Ingresa tu contraseña</label>
+  <input id="inputPassword" data-testid="inputPassword" name="password" type="password" autocomplete="current-password">
+
+  <button type="submit">Ingresar</button>
+</form>
+</body>
+</html>

--- a/tests/scrapers/cl/test_scotiabank.py
+++ b/tests/scrapers/cl/test_scotiabank.py
@@ -848,11 +848,11 @@ class TestScotiabankBrowserConfig:
         assert kw["locale"] == "es-CL"
         assert kw["timezone_id"] == "America/Santiago"
 
-    def test_browser_init_script_contains_webdriver_and_webgl(self, scraper):
-        s = scraper._browser_init_script()
-        assert "webdriver" in s
-        assert "37445" in s
-        assert "37446" in s
+    def test_browser_init_script_returns_none(self, scraper):
+        # Workaround: patchright + real Chrome breaks DNS when add_init_script
+        # is invoked. Patchright already patches webdriver via binary patches.
+        # See scotiabank.py _browser_init_script for full rationale.
+        assert scraper._browser_init_script() is None
 
     def test_playwright_factory_returns_patchright(self, scraper):
         factory = scraper._playwright_factory()

--- a/tests/scrapers/cl/test_scotiabank.py
+++ b/tests/scrapers/cl/test_scotiabank.py
@@ -417,9 +417,7 @@ class TestFixtureStructure:
             html = self._fixture(name)
             ruts_dotted = re.findall(r"\b\d{1,2}\.\d{3}\.\d{3}-[\dkK]\b", html)
             unexpected = [r for r in ruts_dotted if r != "12.345.678-9"]
-            assert not unexpected, (
-                f"{name}: unexpected RUT(s) {unexpected}"
-            )
+            assert not unexpected, f"{name}: unexpected RUT(s) {unexpected}"
             assert not re.search(r"\b\d{7,8}-[\dkK]\b", html), (
                 f"{name}: bare-digit RUT pattern found"
             )
@@ -766,3 +764,56 @@ class TestParseChileanAmountScotiaCases:
         from fintself.utils.parsers import parse_chilean_amount
 
         assert parse_chilean_amount(amount_str) == Decimal(expected)
+
+
+class TestDismissHomePopup:
+    """Tests for _dismiss_home_popup: defensive close of promo modal on home."""
+
+    def test_clicks_close_when_popup_visible(self, scraper, fixture_page):
+        from pathlib import Path
+
+        fixture = (
+            Path(__file__).resolve().parents[2]
+            / "fixtures"
+            / "cl"
+            / "scotiabank"
+            / "home_with_popup.html"
+        )
+        assert fixture.exists(), f"Missing fixture: {fixture}"
+        fixture_page.set_content(fixture.read_text(encoding="utf-8"))
+
+        result = scraper._dismiss_home_popup(fixture_page)
+
+        assert result is True
+
+    def test_returns_false_silently_when_no_popup(
+        self, scraper, fixture_page, monkeypatch
+    ):
+        from pathlib import Path
+
+        fixture = (
+            Path(__file__).resolve().parents[2]
+            / "fixtures"
+            / "cl"
+            / "scotiabank"
+            / "home_without_popup.html"
+        )
+        assert fixture.exists(), f"Missing fixture: {fixture}"
+        fixture_page.set_content(fixture.read_text(encoding="utf-8"))
+        monkeypatch.setattr(scraper, "HOME_PROMO_TIMEOUT_MS", 200)
+
+        result = scraper._dismiss_home_popup(fixture_page)
+
+        assert result is False
+
+    def test_returns_false_when_click_fails(self, scraper, mocker):
+        """Popup detected but click raises — must not crash login flow."""
+        page = mocker.MagicMock()
+        page.wait_for_selector.return_value = None
+        page.locator.return_value.first.click.side_effect = Exception(
+            "click intercepted"
+        )
+
+        result = scraper._dismiss_home_popup(page)
+
+        assert result is False

--- a/tests/scrapers/cl/test_scotiabank.py
+++ b/tests/scrapers/cl/test_scotiabank.py
@@ -1,0 +1,768 @@
+"""Tests for the Scotiabank Chile scraper."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+from fintself.core.exceptions import LoginError
+from fintself.scrapers.cl.scotiabank import ScotiabankScraper
+
+
+@pytest.fixture
+def scraper() -> ScotiabankScraper:
+    s = ScotiabankScraper.__new__(ScotiabankScraper)
+    s.debug_mode = False
+    s.default_timeout = 30000
+    s.min_human_delay_ms = 0
+    s.max_human_delay_ms = 0
+    s.user = "1.234.567-8"
+    s.password = "secret"
+    s.playwright = None
+    s.browser = None
+    s.page = MagicMock()
+    return s
+
+
+class TestBankId:
+    def test_returns_cl_scotiabank(self, scraper):
+        assert scraper._get_bank_id() == "cl_scotiabank"
+
+
+class TestLogin:
+    def test_login_success_flow(self, scraper):
+        page = scraper.page
+
+        acceso_locator = MagicMock()
+        acceso_locator.first.click = MagicMock()
+        personas_locator = MagicMock()
+        personas_locator.click = MagicMock()
+
+        page.get_by_text = MagicMock(return_value=acceso_locator)
+        page.get_by_role = MagicMock(return_value=personas_locator)
+        page.wait_for_selector = MagicMock()
+
+        with (
+            patch.object(scraper, "_ensure_page", return_value=page),
+            patch.object(scraper, "_navigate") as nav,
+            patch.object(scraper, "_save_debug_info"),
+            patch.object(scraper, "_type") as type_mock,
+            patch.object(scraper, "_click") as click_mock,
+            patch.object(scraper, "_dismiss_onboarding_tour") as tour_mock,
+            patch("fintself.scrapers.cl.scotiabank.expect") as mock_expect,
+        ):
+            mock_expect.return_value.to_have_url = MagicMock()
+            scraper._login()
+
+        nav.assert_called_once_with(scraper.HOME_URL, timeout_override=60000)
+        page.get_by_text.assert_called_with("Acceso Scotia")
+        acceso_locator.first.click.assert_called_once()
+        page.get_by_role.assert_called_with("link", name="Ingreso Personas")
+        personas_locator.click.assert_called_once()
+        page.wait_for_selector.assert_called_with(scraper.RUT_INPUT, timeout=30000)
+
+        type_mock.assert_any_call(scraper.RUT_INPUT, scraper.user, delay=120)
+        type_mock.assert_any_call(scraper.PASSWORD_INPUT, scraper.password, delay=120)
+        type_call_order = [c.args[0] for c in type_mock.call_args_list]
+        assert type_call_order == [scraper.RUT_INPUT, scraper.PASSWORD_INPUT], (
+            "RUT must be typed before password"
+        )
+
+        click_mock.assert_called_once_with(scraper.SUBMIT_BUTTON)
+
+        mock_expect.assert_called_once_with(page)
+        to_have_url_call = mock_expect.return_value.to_have_url.call_args
+        url_pattern = to_have_url_call.args[0]
+        assert url_pattern.search(
+            "https://www.scotiabank.cl/mfe/sweb/mfe-shell-web-cl/mfe/mfe/sweb/mfe-home-cl/"
+        )
+        assert not url_pattern.search("https://banco.scotiabank.cl/mfe-login/scotia")
+        assert to_have_url_call.kwargs.get("timeout") == 45000
+
+        tour_mock.assert_called_once_with(page)
+
+    def test_login_raises_when_acceso_scotia_missing(self, scraper):
+        page = scraper.page
+        acceso_locator = MagicMock()
+        acceso_locator.first.click.side_effect = PlaywrightTimeoutError("nope")
+        page.get_by_text = MagicMock(return_value=acceso_locator)
+
+        with (
+            patch.object(scraper, "_ensure_page", return_value=page),
+            patch.object(scraper, "_navigate"),
+            patch.object(scraper, "_save_debug_info"),
+        ):
+            with pytest.raises(LoginError, match="Acceso Scotia"):
+                scraper._login()
+
+    def test_login_raises_when_login_form_never_renders(self, scraper):
+        page = scraper.page
+        acceso_locator = MagicMock()
+        page.get_by_text = MagicMock(return_value=acceso_locator)
+        personas_locator = MagicMock()
+        page.get_by_role = MagicMock(return_value=personas_locator)
+        page.wait_for_selector.side_effect = PlaywrightTimeoutError("no form")
+
+        with (
+            patch.object(scraper, "_ensure_page", return_value=page),
+            patch.object(scraper, "_navigate"),
+            patch.object(scraper, "_save_debug_info"),
+        ):
+            with pytest.raises(LoginError, match="Login form did not render"):
+                scraper._login()
+
+    def test_login_raises_when_dashboard_url_never_arrives(self, scraper):
+        page = scraper.page
+        acceso_locator = MagicMock()
+        personas_locator = MagicMock()
+        page.get_by_text = MagicMock(return_value=acceso_locator)
+        page.get_by_role = MagicMock(return_value=personas_locator)
+        page.wait_for_selector = MagicMock()
+
+        with (
+            patch.object(scraper, "_ensure_page", return_value=page),
+            patch.object(scraper, "_navigate"),
+            patch.object(scraper, "_save_debug_info"),
+            patch.object(scraper, "_type"),
+            patch.object(scraper, "_click"),
+            patch.object(scraper, "_dismiss_onboarding_tour"),
+            patch("fintself.scrapers.cl.scotiabank.expect") as mock_expect,
+        ):
+            mock_expect.return_value.to_have_url.side_effect = AssertionError(
+                "url mismatch"
+            )
+            with pytest.raises(
+                LoginError,
+                match="(Post-login redirect|maintenance|incorrect)",
+            ):
+                scraper._login()
+
+
+class TestDismissOnboardingTour:
+    def test_dismiss_clicks_visible_button_and_exits(self, scraper):
+        scraper.POST_LOGIN_SETTLE_MS = 4000
+        scraper.TOUR_POLL_INTERVAL_MS = 500
+
+        visible_loc = MagicMock()
+        visible_loc.is_visible.return_value = True
+        invisible_loc = MagicMock()
+        invisible_loc.is_visible.return_value = False
+
+        def fake_locator(sel):
+            wrapper = MagicMock()
+            wrapper.first = (
+                visible_loc if sel == "button:has-text('Saltar')" else invisible_loc
+            )
+            return wrapper
+
+        page = MagicMock()
+        page.locator.side_effect = fake_locator
+
+        scraper._dismiss_onboarding_tour(page)
+
+        visible_loc.click.assert_called_once_with(timeout=2000)
+
+    def test_dismiss_never_matches_logout_button(self, scraper):
+        # 'Cerrar sesión' must NOT appear in any tour selector.
+        for sel in scraper.TOUR_DISMISS_SELECTORS:
+            assert "Cerrar sesión" not in sel
+            assert sel != "button:has-text('Cerrar')"
+            assert sel != "button[aria-label='Cerrar']"  # scoped only
+
+    def test_dismiss_silent_on_no_overlay(self, scraper):
+        scraper.POST_LOGIN_SETTLE_MS = 1000
+        scraper.TOUR_POLL_INTERVAL_MS = 500
+        invisible_loc = MagicMock()
+        invisible_loc.is_visible.return_value = False
+
+        page = MagicMock()
+        page.locator.return_value.first = invisible_loc
+
+        scraper._dismiss_onboarding_tour(page)  # must not raise
+
+        invisible_loc.click.assert_not_called()
+
+
+class TestLoginPageFixture:
+    """Sanity check the captured login_page.html still contains expected selectors."""
+
+    def test_fixture_contains_rut_and_password_testids(self):
+        from pathlib import Path
+
+        fixture = (
+            Path(__file__).parent.parent.parent
+            / "fixtures"
+            / "cl"
+            / "scotiabank"
+            / "login_page.html"
+        )
+        assert fixture.exists(), f"Missing fixture: {fixture}"
+        html = fixture.read_text(encoding="utf-8")
+        assert 'data-testid="inputDni"' in html
+        assert 'data-testid="inputPassword"' in html
+        assert "Ingresar" in html
+
+
+class TestCleanText:
+    def test_collapses_whitespace_and_trims(self, scraper):
+        assert scraper._clean_text("  hola\n\t mundo  ") == "hola mundo"
+
+    def test_empty_input_returns_empty(self, scraper):
+        assert scraper._clean_text("") == ""
+        assert scraper._clean_text(None) == ""
+
+
+class TestExtractCheckingMovementsFixture:
+    """Golden-file test: parse the captured checking iframe DOM."""
+
+    def test_parses_all_movement_rows(self, scraper, fixture_page):
+        from pathlib import Path
+
+        html = (
+            Path(__file__).parent.parent.parent
+            / "fixtures"
+            / "cl"
+            / "scotiabank"
+            / "checking_movements.html"
+        ).read_text(encoding="utf-8")
+        fixture_page.set_content(html)
+
+        movements = scraper._extract_checking_movements(fixture_page, account_id="1234")
+
+        assert len(movements) > 0
+        first = movements[0]
+        assert first.currency == "CLP"
+        assert first.account_type == "corriente"
+        assert first.account_id == "1234"
+        assert first.date is not None
+        assert first.description != ""
+        # Sign convention sanity: at least one cargo (<0) AND one abono (>0)
+        # exist in the fixture.
+        assert any(m.amount < 0 for m in movements)
+        assert any(m.amount > 0 for m in movements)
+        for m in movements:
+            assert m.transaction_type in {"Abono", "Cargo"}
+            if m.amount < 0:
+                assert m.transaction_type == "Cargo"
+            if m.amount > 0:
+                assert m.transaction_type == "Abono"
+
+
+class TestExtractCCNacionalFixture:
+    def test_billed_nacional_parses_with_inverted_sign(self, scraper, fixture_page):
+        from pathlib import Path
+
+        html = (
+            Path(__file__).parent.parent.parent
+            / "fixtures"
+            / "cl"
+            / "scotiabank"
+            / "credit_card_billed.html"
+        ).read_text(encoding="utf-8")
+        fixture_page.set_content(html)
+
+        movements = scraper._extract_cc_nacional_movements(
+            fixture_page, account_id="XXXX", transaction_type="Facturado"
+        )
+
+        assert len(movements) > 0
+        for m in movements:
+            assert m.currency == "CLP"
+            assert m.account_type == "credito"
+            assert m.transaction_type == "Facturado"
+        # Sign inversion: raw "$-1.089.139" (abono) → positive in model.
+        # Raw "$205.813" (cargo) → negative in model.
+        positives = [m for m in movements if m.amount > 0]
+        negatives = [m for m in movements if m.amount < 0]
+        assert positives, "Expected at least one abono (positive) after inversion."
+        assert negatives, "Expected at least one cargo (negative) after inversion."
+
+
+class TestExtractCCInternacionalFixture:
+    def test_billed_intl_extracts_usd_and_skips_summary_rows(
+        self, scraper, fixture_page
+    ):
+        from pathlib import Path
+
+        html = (
+            Path(__file__).parent.parent.parent
+            / "fixtures"
+            / "cl"
+            / "scotiabank"
+            / "credit_card_billed.html"
+        ).read_text(encoding="utf-8")
+        fixture_page.set_content(html)
+
+        movements = scraper._extract_cc_internacional_movements(
+            fixture_page, account_id="XXXX", transaction_type="Facturado"
+        )
+
+        assert len(movements) >= 1, "Expected at least one USD movement in fixture."
+        for m in movements:
+            assert m.account_type == "credito"
+            assert m.currency in {"USD", "CLP"}
+            # Summary rows ("TOTAL PAGOS" / "TOTAL COMPRAS") must not appear
+            # because their fecha cell is empty.
+            assert "TOTAL" not in (m.description or "").upper()
+        # Sign inversion: raw "USD -23,80" (abono) → positive; raw
+        # "USD 58,84" (cargo) → negative after inversion.
+        assert any(m.amount > 0 for m in movements), (
+            "Expected at least one inverted-positive (abono) USD movement."
+        )
+        assert any(m.amount < 0 for m in movements), (
+            "Expected at least one inverted-negative (cargo) USD movement."
+        )
+
+
+class TestExtractUnbilledFixture:
+    def test_unbilled_nacional_parses(self, scraper, fixture_page):
+        from pathlib import Path
+
+        html = (
+            Path(__file__).parent.parent.parent
+            / "fixtures"
+            / "cl"
+            / "scotiabank"
+            / "credit_card_unbilled.html"
+        ).read_text(encoding="utf-8")
+        fixture_page.set_content(html)
+
+        movements = scraper._extract_cc_nacional_movements(
+            fixture_page, account_id="XXXX", transaction_type="NoFacturado"
+        )
+
+        assert movements, "Expected at least one unbilled nacional movement."
+        for m in movements:
+            assert m.transaction_type == "NoFacturado"
+            assert m.account_type == "credito"
+            assert m.currency == "CLP"
+
+
+class TestScrapeMovementsOrchestration:
+    def test_aggregates_all_three_sections(self, scraper):
+        with (
+            patch.object(scraper, "_scrape_checking", return_value=["chk"]),
+            patch.object(
+                scraper, "_scrape_credit_card_billed", return_value=["cb1", "cb2"]
+            ),
+            patch.object(scraper, "_scrape_credit_card_unbilled", return_value=["un1"]),
+        ):
+            result = scraper._scrape_movements()
+        assert result == ["chk", "cb1", "cb2", "un1"]
+
+    def test_section_failure_does_not_abort_others(self, scraper):
+        from fintself.core.exceptions import DataExtractionError
+
+        with (
+            patch.object(scraper, "_scrape_checking", return_value=["chk"]),
+            patch.object(
+                scraper,
+                "_scrape_credit_card_billed",
+                side_effect=DataExtractionError("nope"),
+            ),
+            patch.object(scraper, "_scrape_credit_card_unbilled", return_value=["un"]),
+            patch.object(scraper, "_save_debug_info"),
+        ):
+            result = scraper._scrape_movements()
+        assert result == ["chk", "un"]
+
+
+class TestFixtureStructure:
+    """Sanity checks on captured DOM fixtures used by upcoming TDD."""
+
+    @staticmethod
+    def _fixture(name: str) -> str:
+        from pathlib import Path
+
+        return (
+            Path(__file__).parent.parent.parent
+            / "fixtures"
+            / "cl"
+            / "scotiabank"
+            / name
+        ).read_text(encoding="utf-8")
+
+    def test_checking_fixture_has_movement_table(self):
+        html = self._fixture("checking_movements.html")
+        assert 'class="Table__dataTable"' in html
+        assert "TableBody__cell" in html
+        assert "Descripción" in html
+
+    def test_cc_billed_fixture_has_tab_and_table(self):
+        html = self._fixture("credit_card_billed.html")
+        assert "tab-action__movimientos-facturados" in html
+        assert "tabla__movimientos--nacional" in html
+        assert "tabla__movimientos--internacional" in html
+
+    def test_cc_unbilled_fixture_has_unbilled_tab(self):
+        html = self._fixture("credit_card_unbilled.html")
+        assert "tab-action__movimientos-no-facturados" in html
+        assert "tabla__movimientos--nacional" in html
+
+    def test_fixtures_only_use_placeholder_rut(self):
+        """Fixtures only use the documented placeholder values.
+
+        Guards the placeholder-only contract: any RUT other than
+        ``12.345.678-9`` and any card last-4 other than ``****XXXX`` would
+        break this assertion.
+        """
+        import re
+
+        for name in [
+            "checking_movements.html",
+            "credit_card_billed.html",
+            "credit_card_unbilled.html",
+            "login_page.html",
+        ]:
+            html = self._fixture(name)
+            ruts_dotted = re.findall(r"\b\d{1,2}\.\d{3}\.\d{3}-[\dkK]\b", html)
+            unexpected = [r for r in ruts_dotted if r != "12.345.678-9"]
+            assert not unexpected, (
+                f"{name}: unexpected RUT(s) {unexpected}"
+            )
+            assert not re.search(r"\b\d{7,8}-[\dkK]\b", html), (
+                f"{name}: bare-digit RUT pattern found"
+            )
+            cards = re.findall(r"\*{2,}\d{4}\b", html)
+            assert not cards, f"{name}: card last-4 found: {cards}"
+
+
+# ─── New unit tests ──────────────────────────────────────────────────────
+
+
+def _fixture_html(name: str) -> str:
+    from pathlib import Path
+
+    return (
+        Path(__file__).parent.parent.parent / "fixtures" / "cl" / "scotiabank" / name
+    ).read_text(encoding="utf-8")
+
+
+class TestExpandVerMas:
+    """Unit-tests for ``_expand_all_ver_mas`` (SPA pagination loop)."""
+
+    def _make_frame(self, visible_counts: list[int]) -> MagicMock:
+        """Build a Frame mock whose ``Ver más`` button count follows the script.
+
+        ``visible_counts[i]`` is the count returned on the i-th iteration.
+        After the list is exhausted, count returns 0 (button gone).
+        """
+        frame = MagicMock()
+        # anchor locator (always count==0 to skip scroll path)
+        anchor = MagicMock()
+        anchor.count.return_value = 0
+
+        button = MagicMock()
+        button.is_visible.return_value = True
+        # nth(i) returns the same button mock (single-button case).
+        button.nth.return_value = button
+
+        counts_iter = iter(visible_counts)
+
+        def count_side_effect():
+            try:
+                return next(counts_iter)
+            except StopIteration:
+                return 0
+
+        button.count.side_effect = count_side_effect
+
+        def locator_side_effect(selector):
+            if "Ver más" in selector:
+                return button
+            return anchor
+
+        frame.locator.side_effect = locator_side_effect
+        return frame, button
+
+    def test_clicks_until_button_absent(self, scraper):
+        # Button present 3 times, then gone.
+        frame, button = self._make_frame([1, 1, 1])
+        scraper._expand_all_ver_mas(frame, context="t")
+        assert button.click.call_count == 3
+
+    def test_loop_caps_at_30(self, scraper):
+        # Button always present → should cap at 30 clicks.
+        frame = MagicMock()
+        anchor = MagicMock()
+        anchor.count.return_value = 0
+        button = MagicMock()
+        button.is_visible.return_value = True
+        button.nth.return_value = button
+        button.count.return_value = 1
+
+        def locator_side_effect(selector):
+            if "Ver más" in selector:
+                return button
+            return anchor
+
+        frame.locator.side_effect = locator_side_effect
+        scraper._expand_all_ver_mas(frame, context="t")
+        assert button.click.call_count == 30
+
+    def test_returns_silently_when_no_button_present(self, scraper):
+        frame, button = self._make_frame([0])
+        # No exception, no clicks.
+        scraper._expand_all_ver_mas(frame, context="t")
+        button.click.assert_not_called()
+
+
+class TestSelectCcRadio:
+    """Unit-tests for ``_select_cc_radio``."""
+
+    def test_button_present_and_visible_clicked_once_timeout_5000(self, scraper):
+        frame = MagicMock()
+        loc = MagicMock()
+        loc.count.return_value = 1
+        frame.locator.return_value.first = loc
+
+        with patch.object(scraper, "_save_debug_info"):
+            ok = scraper._select_cc_radio(frame, "sel", "nacional", "ctx")
+
+        assert ok is True
+        loc.click.assert_called_once_with(timeout=5000)
+
+    def test_button_count_zero_returns_true(self, scraper):
+        frame = MagicMock()
+        loc = MagicMock()
+        loc.count.return_value = 0
+        frame.locator.return_value.first = loc
+
+        ok = scraper._select_cc_radio(frame, "sel", "internacional", "ctx")
+
+        assert ok is True
+        loc.click.assert_not_called()
+
+    def test_click_raises_returns_false_and_warns(self, scraper):
+        frame = MagicMock()
+        loc = MagicMock()
+        loc.count.return_value = 1
+        loc.click.side_effect = PlaywrightTimeoutError("nope")
+        frame.locator.return_value.first = loc
+
+        with patch("fintself.scrapers.cl.scotiabank.logger") as mock_logger:
+            ok = scraper._select_cc_radio(frame, "sel", "nacional", "ctx")
+
+        assert ok is False
+        assert mock_logger.warning.called
+
+
+class TestGetStageFrame:
+    """Unit-tests for ``_get_stage_frame``."""
+
+    def _frame(self, url: str) -> MagicMock:
+        f = MagicMock()
+        f.url = url
+        return f
+
+    def test_inner_frame_present_immediately(self, scraper):
+        page = MagicMock()
+        inner = self._frame("https://x/mfe-accounts-balancesmovements-web/foo")
+        page.frames = [inner]
+
+        with patch.object(scraper, "_ensure_page", return_value=page):
+            result = scraper._get_stage_frame("mfe-accounts-balancesmovements-web")
+
+        assert result is inner
+
+    def test_polls_until_inner_appears(self, scraper):
+        outer = self._frame(
+            "https://x/mfe-shell-web-cl/mfe/mfe-accounts-balancesmovements-web/"
+        )
+        inner = self._frame("https://x/mfe-accounts-balancesmovements-web/inner")
+
+        # First two reads: only outer. Then inner appears.
+        states = iter([[outer], [outer], [outer, inner], [outer, inner]])
+
+        class FakePage:
+            wait_for_timeout = MagicMock()
+
+            @property
+            def frames(self):
+                try:
+                    return next(states)
+                except StopIteration:
+                    return [outer, inner]
+
+        page = FakePage()
+
+        with patch.object(scraper, "_ensure_page", return_value=page):
+            result = scraper._get_stage_frame("mfe-accounts-balancesmovements-web")
+
+        assert result is inner
+        assert page.wait_for_timeout.called
+
+    def test_timeout_raises_data_extraction_error_and_saves_debug(self, scraper):
+        from fintself.core.exceptions import DataExtractionError
+
+        scraper.IFRAME_WAIT_MS = 1000  # short
+        page = MagicMock()
+        # Only outer shell frame ever present → never satisfies inner check.
+        outer = self._frame("https://x/mfe-shell-web-cl/mfe-accounts-foo/")
+        page.frames = [outer]
+
+        with (
+            patch.object(scraper, "_ensure_page", return_value=page),
+            patch.object(scraper, "_save_debug_info") as dbg,
+        ):
+            with pytest.raises(DataExtractionError):
+                scraper._get_stage_frame("mfe-accounts-foo")
+
+        dbg.assert_called()
+
+
+class TestExtractCardId:
+    """Fixture-driven test for ``_extract_card_id``."""
+
+    def test_returns_card_label(self, scraper, fixture_page):
+        html = _fixture_html("credit_card_billed.html")
+        fixture_page.set_content(html)
+
+        card_id = scraper._extract_card_id(fixture_page)
+
+        assert isinstance(card_id, str)
+        assert card_id != ""
+        assert "****XXXX" in card_id
+
+
+class TestExtractCheckingMovementsEdgeCases:
+    """Fixture-driven edge cases with in-memory HTML mutation."""
+
+    def _rows(self, html: str) -> list[str]:
+        import re
+
+        return re.findall(
+            r'<tr class="TableBody__bodyRow[^>]*>.*?</tr>', html, flags=re.S
+        )
+
+    def test_row_with_empty_amount_cell_is_skipped(self, scraper, fixture_page):
+        import re
+
+        html = _fixture_html("checking_movements.html")
+
+        # Baseline parse FIRST (before mutation).
+        fixture_page.set_content(html)
+        baseline_movements = scraper._extract_checking_movements(
+            fixture_page, account_id="1234"
+        )
+        baseline_count = len(baseline_movements)
+        assert baseline_count > 1
+
+        # Blank out amount cell (5th td, idx=4) of the first row.
+        rows = self._rows(html)
+        first = rows[0]
+        cells = re.findall(r'<td class="TableBody__cell"[^>]*>.*?</td>', first, re.S)
+        assert len(cells) >= 6
+        amount_td = cells[4]
+        new_amount_td = re.sub(
+            r'(<td class="TableBody__cell"[^>]*>).*?(</td>)',
+            r"\1\2",
+            amount_td,
+            count=1,
+            flags=re.S,
+        )
+        mutated_first = first.replace(amount_td, new_amount_td, 1)
+        mutated_html = html.replace(first, mutated_first, 1)
+        fixture_page.set_content(mutated_html)
+
+        movements = scraper._extract_checking_movements(fixture_page, account_id="1234")
+        # One fewer movement than baseline (zero-amount row was skipped).
+        assert len(movements) == baseline_count - 1
+
+    def test_malformed_date_row_skipped_others_extracted(self, scraper, fixture_page):
+        import re
+
+        html = _fixture_html("checking_movements.html")
+        rows = self._rows(html)
+        first = rows[0]
+        cells = re.findall(r'<td class="TableBody__cell"[^>]*>.*?</td>', first, re.S)
+        date_td = cells[1]
+        bad_date_td = re.sub(
+            r'(<td class="TableBody__cell"[^>]*>)(.*?)(</td>)',
+            r"\g<1>99-99-9999\g<3>",
+            date_td,
+            count=1,
+            flags=re.S,
+        )
+        mutated_first = first.replace(date_td, bad_date_td, 1)
+        mutated_html = html.replace(first, mutated_first, 1)
+        fixture_page.set_content(mutated_html)
+
+        movements = scraper._extract_checking_movements(fixture_page, account_id="1234")
+        # Other rows still parsed successfully.
+        assert len(movements) > 0
+
+    def test_empty_tbody_returns_empty_list(self, scraper, fixture_page):
+        import re
+
+        html = _fixture_html("checking_movements.html")
+        # Remove all rows from the tbody.
+        mutated = re.sub(
+            r'(<tbody class="TableBody">).*?(</tbody>)',
+            r"\1\2",
+            html,
+            count=1,
+            flags=re.S,
+        )
+        fixture_page.set_content(mutated)
+
+        movements = scraper._extract_checking_movements(fixture_page, account_id="1234")
+        assert movements == []
+
+
+class TestFixtureIntegrity:
+    """Enforce the placeholder-only convention documented for these fixtures."""
+
+    FIXTURES = [
+        "checking_movements.html",
+        "credit_card_billed.html",
+        "credit_card_unbilled.html",
+        "login_page.html",
+    ]
+
+    PLACEHOLDER_RUT = "12.345.678-9"
+
+    def test_only_placeholder_rut(self):
+        import re
+
+        for name in self.FIXTURES:
+            html = _fixture_html(name)
+            ruts = re.findall(r"\b\d{1,2}\.\d{3}\.\d{3}-[\dkK]\b", html)
+            unexpected = [r for r in ruts if r != self.PLACEHOLDER_RUT]
+            assert not unexpected, f"{name}: unexpected RUT(s) {unexpected}"
+            assert not re.search(r"\b\d{7,8}-[\dkK]\b", html), name
+
+    def test_no_email_addresses(self):
+        import re
+
+        pattern = re.compile(r"[\w.+-]+@[\w.-]+\.\w{2,}")
+        for name in self.FIXTURES:
+            html = _fixture_html(name)
+            found = set(pattern.findall(html))
+            assert not found, f"{name}: unexpected email(s) {found}"
+
+    def test_no_16_digit_groups(self):
+        import re
+
+        pattern = re.compile(r"(?<!\d)\d{16}(?!\d)")
+        for name in self.FIXTURES:
+            html = _fixture_html(name)
+            found = set(pattern.findall(html))
+            assert not found, f"{name}: unexpected 16-digit group(s) {found}"
+
+
+class TestParseChileanAmountScotiaCases:
+    @pytest.mark.parametrize(
+        "amount_str, expected",
+        [
+            ("$-1.500.000", "-1500000"),
+            ("USD -23,80", "-23.80"),
+            ("$ ", "0"),
+        ],
+    )
+    def test_scotia_amount_strings(self, amount_str, expected):
+        from decimal import Decimal
+
+        from fintself.utils.parsers import parse_chilean_amount
+
+        assert parse_chilean_amount(amount_str) == Decimal(expected)

--- a/tests/scrapers/cl/test_scotiabank.py
+++ b/tests/scrapers/cl/test_scotiabank.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+from patchright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from fintself.core.exceptions import LoginError
 from fintself.scrapers.cl.scotiabank import ScotiabankScraper
@@ -21,6 +21,9 @@ def scraper() -> ScotiabankScraper:
     s.playwright = None
     s.browser = None
     s.page = MagicMock()
+    s.headless = False
+    s.locale = "es-CL"
+    s.timezone_id = "America/Santiago"
     return s
 
 
@@ -817,3 +820,41 @@ class TestDismissHomePopup:
         result = scraper._dismiss_home_popup(page)
 
         assert result is False
+
+
+class TestScotiabankImports:
+    def test_uses_patchright_not_playwright(self):
+        import inspect
+        from fintself.scrapers.cl import scotiabank as mod
+        src = inspect.getsource(mod)
+        assert "from patchright.sync_api" in src
+        for line in src.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("from playwright.sync_api") and not stripped.startswith("#"):
+                raise AssertionError(f"Leftover playwright import: {line!r}")
+
+
+class TestScotiabankBrowserConfig:
+    def test_browser_launch_kwargs_uses_chrome_channel(self, scraper):
+        kw = scraper._browser_launch_kwargs()
+        assert kw["channel"] == "chrome"
+        assert "ignore_default_args" in kw
+        assert "--enable-automation" in kw["ignore_default_args"]
+
+    def test_browser_context_kwargs_has_sec_ch_ua(self, scraper):
+        kw = scraper._browser_context_kwargs()
+        assert "extra_http_headers" in kw
+        assert "sec-ch-ua-platform" in kw["extra_http_headers"]
+        assert kw["locale"] == "es-CL"
+        assert kw["timezone_id"] == "America/Santiago"
+
+    def test_browser_init_script_contains_webdriver_and_webgl(self, scraper):
+        s = scraper._browser_init_script()
+        assert "webdriver" in s
+        assert "37445" in s
+        assert "37446" in s
+
+    def test_playwright_factory_returns_patchright(self, scraper):
+        factory = scraper._playwright_factory()
+        cm = factory()
+        assert "patchright" in type(cm).__module__

--- a/tests/scrapers/test_base_hooks.py
+++ b/tests/scrapers/test_base_hooks.py
@@ -1,0 +1,86 @@
+"""Tests for the 4 opt-in hooks on BaseScraper.
+
+Default behavior must preserve legacy: same kwargs to launch/new_context
+and the same single-line navigator.webdriver init script.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from fintself.scrapers.base import BaseScraper
+
+
+class _DummyScraper(BaseScraper):
+    """Minimal concrete subclass to instantiate BaseScraper for tests."""
+
+    def _get_bank_id(self) -> str:
+        return "test_dummy"
+
+    def _login(self) -> None:
+        pass
+
+    def _scrape_movements(self):
+        return []
+
+
+@pytest.fixture
+def scraper():
+    return _DummyScraper(headless=True, debug_mode=False)
+
+
+class TestDefaultHooks:
+    def test_default_browser_launch_kwargs_preserves_legacy(self, scraper):
+        kw = scraper._browser_launch_kwargs()
+        assert "headless" in kw
+        assert "slow_mo" in kw
+        assert "channel" not in kw
+        assert "ignore_default_args" not in kw
+
+    def test_default_browser_context_kwargs_preserves_legacy(self, scraper):
+        kw = scraper._browser_context_kwargs()
+        assert "user_agent" in kw
+        assert "viewport" in kw
+        assert "locale" in kw
+        assert "timezone_id" in kw
+        assert "extra_http_headers" not in kw
+        assert "device_scale_factor" not in kw
+
+    def test_default_browser_init_script_is_legacy_one_liner(self, scraper):
+        s = scraper._browser_init_script()
+        assert s is not None
+        assert "webdriver" in s
+        assert "\n" not in s.strip()
+
+    def test_default_playwright_factory_returns_playwright_sync(self, scraper):
+        factory = scraper._playwright_factory()
+        cm = factory()
+        assert "playwright" in type(cm).__module__
+        assert "patchright" not in type(cm).__module__
+
+
+class TestSubclassOverrides:
+    def test_subclass_can_override_launch_kwargs(self):
+        class Custom(_DummyScraper):
+            def _browser_launch_kwargs(self):
+                return {"channel": "chrome", "headless": False, "args": ["--x"]}
+
+        s = Custom()
+        assert s._browser_launch_kwargs() == {"channel": "chrome", "headless": False, "args": ["--x"]}
+
+    def test_subclass_can_override_init_script(self):
+        class Custom(_DummyScraper):
+            def _browser_init_script(self):
+                return "console.log('custom');"
+
+        s = Custom()
+        assert s._browser_init_script() == "console.log('custom');"
+
+    def test_subclass_can_override_playwright_factory(self):
+        sentinel = MagicMock()
+
+        class Custom(_DummyScraper):
+            def _playwright_factory(self):
+                return sentinel
+
+        s = Custom()
+        assert s._playwright_factory() is sentinel

--- a/tests/utils/test_fingerprint.py
+++ b/tests/utils/test_fingerprint.py
@@ -122,3 +122,52 @@ class TestContextKwargs:
         with p1, p2, p3:
             ck = fingerprint.context_kwargs()
         assert ck["viewport"] == ck["screen"]
+
+
+class TestInitScript:
+    def test_contains_webdriver_override(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            s = fingerprint.init_script()
+        assert "'webdriver'" in s
+        assert "() => undefined" in s
+
+    def test_contains_webgl_param_overrides(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            s = fingerprint.init_script()
+        assert "37445" in s
+        assert "37446" in s
+
+    def test_mac_webgl_renderer_is_apple(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            s = fingerprint.init_script()
+        assert "Apple" in s
+
+    def test_non_mac_webgl_renderer_is_intel(self):
+        p1, p2, p3 = _with_platform("Windows")
+        with p1, p2, p3:
+            s = fingerprint.init_script()
+        assert "Intel" in s
+
+    def test_contains_chrome_runtime_stub(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            s = fingerprint.init_script()
+        assert "window.chrome" in s
+        assert "runtime" in s
+
+    def test_contains_permissions_query_patch(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            s = fingerprint.init_script()
+        assert "navigator.permissions.query" in s
+        assert "notifications" in s
+
+    def test_braces_balanced(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            s = fingerprint.init_script()
+        assert s.count("{") == s.count("}")
+        assert s.count("(") == s.count(")")

--- a/tests/utils/test_fingerprint.py
+++ b/tests/utils/test_fingerprint.py
@@ -80,3 +80,45 @@ class TestBrowserLaunchKwargs:
             kw = fingerprint.browser_launch_kwargs(headless=False)
         assert kw["headless"] is False
         assert "--window-position=-2400,-2400" not in kw["args"]
+
+
+class TestContextKwargs:
+    def test_mac_user_agent_contains_macintosh(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            ck = fingerprint.context_kwargs()
+        assert "Macintosh" in ck["user_agent"]
+        assert "Chrome/131" in ck["user_agent"]
+
+    def test_sec_ch_ua_platform_matches_ua(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            ck = fingerprint.context_kwargs()
+        assert ck["extra_http_headers"]["sec-ch-ua-platform"] == '"macOS"'
+        assert ck["extra_http_headers"]["sec-ch-ua-mobile"] == "?0"
+
+    def test_mac_uses_retina_scale_factor(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            ck = fingerprint.context_kwargs()
+        assert ck["device_scale_factor"] == 2
+
+    def test_non_mac_uses_scale_factor_one(self):
+        p1, p2, p3 = _with_platform("Windows")
+        with p1, p2, p3:
+            ck = fingerprint.context_kwargs()
+        assert ck["device_scale_factor"] == 1
+        assert "Windows NT 10.0" in ck["user_agent"]
+
+    def test_passes_locale_and_timezone(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            ck = fingerprint.context_kwargs(locale="es-CL", timezone="America/Santiago")
+        assert ck["locale"] == "es-CL"
+        assert ck["timezone_id"] == "America/Santiago"
+
+    def test_viewport_and_screen_consistent(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            ck = fingerprint.context_kwargs()
+        assert ck["viewport"] == ck["screen"]

--- a/tests/utils/test_fingerprint.py
+++ b/tests/utils/test_fingerprint.py
@@ -46,40 +46,39 @@ class TestHostProfile:
 
 
 class TestBrowserLaunchKwargs:
-    def test_macos_default_uses_offscreen_window(self):
+    """Pattern: always pass headless=False to Playwright (so it does NOT inject
+    legacy --headless), then add --headless=new manually for invisibility."""
+
+    def test_default_is_invisible_via_headless_new(self):
         p1, p2, p3 = _with_platform("Darwin")
         with p1, p2, p3:
             kw = fingerprint.browser_launch_kwargs()
         assert kw["channel"] == "chrome"
         assert kw["headless"] is False
+        assert "--headless=new" in kw["args"]
         assert "--disable-blink-features=AutomationControlled" in kw["args"]
-        assert "--window-position=-2400,-2400" in kw["args"]
-        assert "--window-size=1440,900" in kw["args"]
         assert kw["ignore_default_args"] == ["--enable-automation"]
-        assert "--headless=new" not in kw["args"]
 
-    def test_linux_default_uses_new_headless(self):
+    def test_default_invisible_on_linux_too(self):
         p1, p2, p3 = _with_platform("Linux", machine="x86_64")
         with p1, p2, p3:
             kw = fingerprint.browser_launch_kwargs()
-        assert kw["channel"] == "chrome"
-        assert kw["headless"] is True
+        assert kw["headless"] is False
         assert "--headless=new" in kw["args"]
-        assert "--window-position=-2400,-2400" not in kw["args"]
 
-    def test_explicit_headless_true_on_mac_respected(self):
+    def test_headless_true_same_as_default(self):
         p1, p2, p3 = _with_platform("Darwin")
         with p1, p2, p3:
             kw = fingerprint.browser_launch_kwargs(headless=True)
-        assert kw["headless"] is True
-        assert "--window-position=-2400,-2400" not in kw["args"]
+        assert kw["headless"] is False
+        assert "--headless=new" in kw["args"]
 
-    def test_explicit_headless_false_on_linux_adds_offscreen_on_mac_only(self):
-        p1, p2, p3 = _with_platform("Linux", machine="x86_64")
+    def test_headless_false_means_visible_for_debug(self):
+        p1, p2, p3 = _with_platform("Darwin")
         with p1, p2, p3:
             kw = fingerprint.browser_launch_kwargs(headless=False)
         assert kw["headless"] is False
-        assert "--window-position=-2400,-2400" not in kw["args"]
+        assert "--headless=new" not in kw["args"]
 
 
 class TestContextKwargs:

--- a/tests/utils/test_fingerprint.py
+++ b/tests/utils/test_fingerprint.py
@@ -1,0 +1,45 @@
+from unittest.mock import patch
+
+from fintself.utils import fingerprint
+
+
+def _with_platform(sysname: str, machine: str = "arm64", mac_ver: str = "15.0.0"):
+    p1 = patch("fintself.utils.fingerprint.platform.system", return_value=sysname)
+    p2 = patch("fintself.utils.fingerprint.platform.machine", return_value=machine)
+    p3 = patch("fintself.utils.fingerprint.platform.mac_ver", return_value=(mac_ver, ("", "", ""), ""))
+    return p1, p2, p3
+
+
+class TestHostProfile:
+    def test_darwin_returns_mac_fields(self):
+        p1, p2, p3 = _with_platform("Darwin", machine="arm64", mac_ver="15.0.0")
+        with p1, p2, p3:
+            prof = fingerprint.host_profile()
+        assert prof["sysname"] == "Darwin"
+        assert "Macintosh" in prof["ua_os"]
+        assert prof["ch_platform"] == '"macOS"'
+        assert prof["ch_platform_version"] == '"15.0.0"'
+        assert prof["nav_platform"] == "MacIntel"
+        assert prof["arch"] == '"arm64"'
+        assert prof["is_mac"] is True
+
+    def test_windows_returns_win_fields(self):
+        p1, p2, p3 = _with_platform("Windows", machine="AMD64")
+        with p1, p2, p3:
+            prof = fingerprint.host_profile()
+        assert prof["sysname"] == "Windows"
+        assert "Windows NT 10.0" in prof["ua_os"]
+        assert prof["ch_platform"] == '"Windows"'
+        assert prof["nav_platform"] == "Win32"
+        assert prof["arch"] == '"x86"'
+        assert prof["is_mac"] is False
+
+    def test_linux_returns_linux_fields(self):
+        p1, p2, p3 = _with_platform("Linux", machine="x86_64")
+        with p1, p2, p3:
+            prof = fingerprint.host_profile()
+        assert prof["sysname"] == "Linux"
+        assert "X11; Linux x86_64" in prof["ua_os"]
+        assert prof["ch_platform"] == '"Linux"'
+        assert prof["nav_platform"] == "Linux x86_64"
+        assert prof["is_mac"] is False

--- a/tests/utils/test_fingerprint.py
+++ b/tests/utils/test_fingerprint.py
@@ -43,3 +43,40 @@ class TestHostProfile:
         assert prof["ch_platform"] == '"Linux"'
         assert prof["nav_platform"] == "Linux x86_64"
         assert prof["is_mac"] is False
+
+
+class TestBrowserLaunchKwargs:
+    def test_macos_default_uses_offscreen_window(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            kw = fingerprint.browser_launch_kwargs()
+        assert kw["channel"] == "chrome"
+        assert kw["headless"] is False
+        assert "--disable-blink-features=AutomationControlled" in kw["args"]
+        assert "--window-position=-2400,-2400" in kw["args"]
+        assert "--window-size=1440,900" in kw["args"]
+        assert kw["ignore_default_args"] == ["--enable-automation"]
+        assert "--headless=new" not in kw["args"]
+
+    def test_linux_default_uses_new_headless(self):
+        p1, p2, p3 = _with_platform("Linux", machine="x86_64")
+        with p1, p2, p3:
+            kw = fingerprint.browser_launch_kwargs()
+        assert kw["channel"] == "chrome"
+        assert kw["headless"] is True
+        assert "--headless=new" in kw["args"]
+        assert "--window-position=-2400,-2400" not in kw["args"]
+
+    def test_explicit_headless_true_on_mac_respected(self):
+        p1, p2, p3 = _with_platform("Darwin")
+        with p1, p2, p3:
+            kw = fingerprint.browser_launch_kwargs(headless=True)
+        assert kw["headless"] is True
+        assert "--window-position=-2400,-2400" not in kw["args"]
+
+    def test_explicit_headless_false_on_linux_adds_offscreen_on_mac_only(self):
+        p1, p2, p3 = _with_platform("Linux", machine="x86_64")
+        with p1, p2, p3:
+            kw = fingerprint.browser_launch_kwargs(headless=False)
+        assert kw["headless"] is False
+        assert "--window-position=-2400,-2400" not in kw["args"]

--- a/tutorials/run_all_scrapers_visible.py
+++ b/tutorials/run_all_scrapers_visible.py
@@ -17,6 +17,7 @@ BANKS_TO_SCRAPE = [
     "cl_banco_chile",
     "cl_cencosud",
     "cl_bice",
+    "cl_scotiabank",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -447,6 +447,7 @@ dependencies = [
     { name = "loguru" },
     { name = "openpyxl" },
     { name = "pandas" },
+    { name = "patchright" },
     { name = "playwright" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -478,6 +479,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.3.1" },
+    { name = "patchright", specifier = ">=1.49.0" },
     { name = "playwright", specifier = ">=1.42.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
@@ -1409,6 +1411,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d4/de/53e0bcf53d13e005bd8c92e7855142494f41171b34c2536b86187474184d/parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a", size = 401205, upload-time = "2025-08-23T15:15:28.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887", size = 106668, upload-time = "2025-08-23T15:15:25.663Z" },
+]
+
+[[package]]
+name = "patchright"
+version = "1.59.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/1d/e6a4b7ff95c35617495a9b686cbf78a968f26ad51c91cef6b2a5eee88f3e/patchright-1.59.1-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:de2e0ea51a270e77ef6588bea1370510695cb94fe6ef848bc7e587d3458764ea", size = 43143713, upload-time = "2026-04-29T08:02:46.651Z" },
+    { url = "https://files.pythonhosted.org/packages/de/55/0b4bb56c141f2906e212c5b31f21ba6107a98105240c173b54d72c74f480/patchright-1.59.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e93fe960714c39152ea3300b7a2c3882cb8d1f992f6120db53406b5590fa4208", size = 41933976, upload-time = "2026-04-29T08:02:51.531Z" },
+    { url = "https://files.pythonhosted.org/packages/72/fc/98ad4f09613051b8c673701043ba6744a213175b01399e555b73de742006/patchright-1.59.1-py3-none-macosx_11_0_universal2.whl", hash = "sha256:bfaad3600817f271ccab34db9f33bb8148c649a157bad28b727097d0b45b8c5d", size = 43143717, upload-time = "2026-04-29T08:02:55.619Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cc/f62063e59db98b154d9faf79603164d548f5117c95acc9d2a8104df9607a/patchright-1.59.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:f0a7ee31e56391a96cd81f9ac1db130e8166c6083b7f3fb3bc9ba19d80d68127", size = 47138586, upload-time = "2026-04-29T08:03:00.04Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/74/2965635dd1d461243281e1774f78d865c2d1df24808cbe3b27a5ede64d7e/patchright-1.59.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69165d20308a045ddf1ad512467625248c5763ea9ee36ee57b0003d1ff8b9b12", size = 46864405, upload-time = "2026-04-29T08:03:04.825Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c2/959acc3fd3d867af4e567bb5e0cc63d4b1ca17fe4b7f673b3eef52fbf287/patchright-1.59.1-py3-none-win32.whl", hash = "sha256:56d9f2f3325f7205dfe6d22abc0969378225cd58b6ce29e7a7e3526c1d78c160", size = 37700491, upload-time = "2026-04-29T08:03:09.81Z" },
+    { url = "https://files.pythonhosted.org/packages/19/b1/1e7a4844ed6bc6bd3653c6e708f614a2b27ac54875ebd0e9c7badf7d25b6/patchright-1.59.1-py3-none-win_amd64.whl", hash = "sha256:3af6515b6103aedd1cdd09be7fa08ac028a954c6687d73fdee92570ae580fe4c", size = 37700495, upload-time = "2026-04-29T08:03:13.727Z" },
+    { url = "https://files.pythonhosted.org/packages/10/95/b148a41c6a099cd3d9f11a0641e4f10d50141cb8dca052f75f64dc631634/patchright-1.59.1-py3-none-win_arm64.whl", hash = "sha256:e259fae74b59a89ee020703ba142b8b5dd81a08f1c95ee3cda92829026057092", size = 33943539, upload-time = "2026-04-29T08:03:17.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `cl_scotiabank` (`ScotiabankScraper`) to extract movements from Scotiabank Chile personas:

- Checking — cuenta corriente (`CTACTE`) "Saldos y últimos movimientos".
- Credit card billed — `Movimientos facturados`, nacional (CLP) + internacional (USD).
- Credit card unbilled — `Movimientos por facturar`, nacional (CLP) + internacional (USD).

## Implementation notes

- Login via the public home (`Acceso Scotia` → `Ingreso Personas`) using `data-testid` inputs.
- Per-section navigation goes directly to the MFE shell URLs (the dashboard menu lives in shadow DOM and click events do not propagate reliably).
- `_get_stage_frame()` picks the inner content frame and filters out the outer shell wrapper that matches the same URL fragment.
- Nacional / Internacional sub-tabs are `button.tab__action` (not radio inputs); the scraper clicks them explicitly.
- `_expand_all_ver_mas` clicks "Ver más Movimientos" until rows stop growing (hard cap at 30 iterations).
- Credit-card sign convention is inverted vs the project standard, so the extractor flips the sign before building `MovementModel`.
- Tour-dismiss heuristic explicitly avoids the bare substring `Cerrar` (that string is the logout button text).
- Selector constants use OR-chain fallbacks against renamed BEM classes (e.g. `table.Table__dataTable, table#table-table`).

## Limitations

Tested against a single-product profile (one `CTACTE` + one credit card). Multi-account / multi-card profiles would have extra products silently skipped — the extension points are documented in the class docstring, the README footnote, the fixtures README, and `docs/scrapers/recon/cl_scotiabank.md`.

## Tests

- `uv run pytest -q` → 84 passed, ruff clean.
- Fixture-driven tests run against hand-crafted HTML that uses only the placeholder values documented in `CONTRIBUTING.md`; the `TestFixtureIntegrity` class enforces the contract on every commit.

## Files

- `fintself/scrapers/cl/scotiabank.py` (new)
- `fintself/scrapers/cl/__init__.py`, `fintself/scrapers/__init__.py` — factory wiring
- `.env.example`, `README.md`, `CONTRIBUTING.md`, `tutorials/run_all_scrapers_visible.py`
- `tests/scrapers/cl/test_scotiabank.py`, `tests/conftest.py`
- `tests/fixtures/cl/scotiabank/{login_page,checking_movements,credit_card_billed,credit_card_unbilled}.html` + `README.md`
- `docs/scrapers/recon/cl_scotiabank.md`
- `.gitignore` — ignore local `recon/`, `scripts/_*.py`, `RESUME.md`

## Test plan

- [x] `uv run pytest -q`
- [x] `uv run ruff check fintself tests`
- [x] Live extraction in visible mode (with valid `CL_SCOTIABANK_USER` / `CL_SCOTIABANK_PASSWORD`)