### PR TITLE
fix(scrapers): use full Chromium binary in headless mode

### DIFF
--- a/fintself/scrapers/base.py
+++ b/fintself/scrapers/base.py
@@ -333,9 +333,21 @@ class BaseScraper(ABC):
                 logger.info(
                     f"Launching browser for {self._get_bank_id()} (headless: {self.headless})..."
                 )
-                self.browser = self.playwright.chromium.launch(
-                    headless=self.headless, slow_mo=self.slow_mo
-                )
+                launch_options = {"headless": self.headless, "slow_mo": self.slow_mo}
+                if self.headless:
+                    # The default headless mode uses Playwright's lightweight
+                    # "headless shell" binary, which some banks (e.g. Banco de
+                    # Chile) serve a degraded page to. The "chromium" channel
+                    # runs the full browser binary in new-headless mode, which
+                    # behaves like a headed session.
+                    launch_options["channel"] = "chromium"
+                try:
+                    self.browser = self.playwright.chromium.launch(**launch_options)
+                except Exception:
+                    # Fall back to the default binary if the full Chromium
+                    # channel is not installed on this machine.
+                    launch_options.pop("channel", None)
+                    self.browser = self.playwright.chromium.launch(**launch_options)
 
                 context_options = {
                     "user_agent": self.user_agent,


### PR DESCRIPTION
## Summary

Playwright's default headless mode launches the lightweight `chromium-headless-shell` binary. Some banks — Banco de Chile in particular — serve a degraded page to it, so the expected elements never render and the scrape fails in headless mode.

This requests the `chromium` **channel** when `headless=True`, so Playwright launches the full browser binary in new-headless mode, which behaves like a headed session. When the full Chromium binary isn't installed, it falls back to the default launch.

### Changes
- `fintself/scrapers/base.py`: build the launch options and add `channel="chromium"` for headless runs, with a fallback.

### Testing
- `ruff format` / `ruff check`: clean
- `pytest`: 44 passed

### Notes
- Related to #28 (Banco de Chile). That report is in **visible** mode (`headless: False`), which already uses the full binary, so this change targets the headless path specifically and may not resolve that case on its own.